### PR TITLE
Added check for pipdeptree to Makefile

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -29,7 +29,7 @@ reset: ## Reset your local environment. Useful after switching branches, etc.
 reset: venv-check venv-wipe install-local fab-get-data django-migrate django-dev-createsuperuser
 
 check: ## Check for any obvious errors in the project's setup.
-check: django-check npm-check
+check: pipdeptree-check django-check npm-check
 
 format: ## Run this project's code formatters.
 format: yapf-format isort-format
@@ -176,6 +176,11 @@ yapf-lint:
 
 yapf-format:
 	yapf -r -i -p --exclude="*/migrations/*.py" --style .style.yapf {{ cookiecutter.project_slug }} apps
+
+
+#pipdeptree
+pipdeptree-check:
+	pipdeptree --warn fail > /dev/null
 
 
 # Help

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -29,13 +29,13 @@ reset: ## Reset your local environment. Useful after switching branches, etc.
 reset: venv-check venv-wipe install-local fab-get-data django-migrate django-dev-createsuperuser
 
 check: ## Check for any obvious errors in the project's setup.
-check: pipdeptree-check django-check npm-check
+check: pipdeptree-check npm-check django-check
 
 format: ## Run this project's code formatters.
 format: yapf-format isort-format
 
 lint: ## Lint the project.
-lint: yapf-lint isort-lint flake8-lint jshint-lint
+lint: npm-install yapf-lint isort-lint flake8-lint jshint-lint
 
 test: ## Run unit and integration tests.
 test: django-test

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -21,7 +21,7 @@ blanc-admin-theme==1.0.2
 sorl-thumbnail==12.3
 
 # Glitter
-django-glitter==0.1.8
+django-glitter==0.1.12
 django-mptt==0.8.7
 django-mptt-admin==0.4.4
 six==1.10.0

--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -11,3 +11,4 @@ isort==4.2.5
 unittest-xml-reporting==2.1.0
 coverage==4.3.4
 yapf==0.16.1
+pipdeptree==0.10.1

--- a/{{cookiecutter.project_slug}}/requirements/testing.txt
+++ b/{{cookiecutter.project_slug}}/requirements/testing.txt
@@ -6,3 +6,4 @@ isort==4.2.5
 unittest-xml-reporting==2.1.0
 coverage==4.3.4
 yapf==0.16.1
+pipdeptree==0.10.1


### PR DESCRIPTION
Fixes #58 

After going through and adding `@` to all the commands, it makes the Makefile a bit harder to see what's going. Will take your recommendation and remove the `@` from the chichestersqp makefile too.