### PR TITLE
Allow all hosts locally

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/local.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/local.py
@@ -16,7 +16,8 @@ DATABASES = {
     },
 }
 
-INTERNAL_IPS = ('127.0.0.1',)
+INTERNAL_IPS = ['127.0.0.1']
+ALLOWED_HOSTS = ['*']
 
 INSTALLED_APPS += [
     'django_extensions',


### PR DESCRIPTION
This requirement creeped in a later Django 1.8 version.

Let's get it in the template so we don't have to update each project manually!