### PR TITLE
Have /static/vendor/ where jshint isn't run

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -169,7 +169,7 @@ npm-run-production:
 
 # JSHint
 jshint-lint:
-	npm run jshint -- static/
+	npm run jshint -- --exclude="static/vendor/" static/
 
 
 # YAPF


### PR DESCRIPTION
Too many third party files which won't pass jshint tests get annoying, so standardise on static/vendor being the location for third party files.

Think we agreed on this one, as it could be CSS, SASS, javascript, or anything!