### PR TITLE
Enable all warnings during tests by default

### DIFF
--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -31,3 +31,4 @@ commands = make test-report
 setenv =
     DJANGO_SETTINGS_MODULE = {{ cookiecutter.project_slug }}.settings.tox
     STATIC_ROOT = {envtmpdir}/static
+    PYTHONWARNINGS = all


### PR DESCRIPTION
We can only fix a problem if we know about it - let's enable all warnings to encourage best practice