### PR TITLE
Use an email as the default dev superuser username

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -142,7 +142,7 @@ django-collectstatic:
 django-check-validate-templates:
 	./manage.py validate_templates --verbosity 0
 
-django-dev-createsuperuser: DJANGO_DEV_USERNAME ?= _dev
+django-dev-createsuperuser: DJANGO_DEV_USERNAME ?= _dev@dev.ngo
 django-dev-createsuperuser: DJANGO_DEV_PASSWORD ?= password
 django-dev-createsuperuser: DJANGO_DEV_EMAIL ?= _dev@dev.ngo
 django-dev-createsuperuser:


### PR DESCRIPTION
Some sites we use a regular username, other sites we use an email. I don't mind the mix - however life is easier when the locally created login is the same across all sites.