### PR TITLE
Django 1.11

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 The Developer Society Django Template
 =====================================
 
-It only supports python3.
+It only supports Python 3.
 
 Installation
 ------------

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,7 +1,7 @@
 {
     "project_name": "Project Name",
     "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '').replace('-', '').replace('_', '') }}",
-    "django_version": ["1.8"],
+    "django_version": ["1.11"],
     "geodjango": "n",
     "glitter": "n",
     "_copy_without_render": [

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,7 +3,7 @@
     "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '').replace('-', '').replace('_', '') }}",
     "django_version": ["1.11"],
     "geodjango": "n",
-    "glitter": "n",
+    "glitter": ["n"],
     "_copy_without_render": [
         "static",
         "templates"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = django, geodjango, glitter
+envlist = django, geodjango
 skipsdist = true
 
 [testenv]
@@ -22,9 +22,4 @@ commands =
 [testenv:geodjango]
 commands =
     cookiecutter --no-input {toxinidir} geodjango=y
-    bash -c "cd projectname && tox"
-
-[testenv:glitter]
-commands =
-    cookiecutter --no-input {toxinidir} glitter=y
     bash -c "cd projectname && tox"

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ envlist = django, geodjango
 skipsdist = true
 
 [testenv]
-basepython = python3.5
-envdir = {toxworkdir}/py35
+basepython = python3.6
+envdir = {toxworkdir}/py36
 deps =
     cookiecutter==1.6.0
 changedir = {envtmpdir}

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -127,10 +127,7 @@ coverage-clean:
 # Django
 django-check: django-check-missing-migrations django-check-validate-templates
 
-django-drop-test-database:
-	./manage.py drop_test_database --noinput
-
-django-test: django-collectstatic django-drop-test-database
+django-test: django-collectstatic
 	coverage run --include="{{ cookiecutter.project_slug }}/*,apps/*" ./manage.py test --noinput . apps
 
 django-check-missing-migrations:

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -131,7 +131,7 @@ django-test: django-collectstatic
 	coverage run --include="{{ cookiecutter.project_slug }}/*,apps/*" ./manage.py test --noinput . apps
 
 django-check-missing-migrations:
-	! ./manage.py makemigrations --dry-run --exit
+	./manage.py makemigrations --settings={{ cookiecutter.project_slug }}.settings.migrations --check --dry-run
 
 django-collectstatic:
 	./manage.py collectstatic --verbosity 0 --noinput

--- a/{{cookiecutter.project_slug}}/apps/core/__init__.py
+++ b/{{cookiecutter.project_slug}}/apps/core/__init__.py
@@ -1,0 +1,6 @@
+from django.forms.fields import CharField
+
+from .validators import ProhibitNullCharactersValidator
+
+# Make CharField form field prohibit null characters
+CharField.default_validators.append(ProhibitNullCharactersValidator())

--- a/{{cookiecutter.project_slug}}/apps/core/validators.py
+++ b/{{cookiecutter.project_slug}}/apps/core/validators.py
@@ -1,0 +1,27 @@
+from django.core.exceptions import ValidationError
+from django.utils.deconstruct import deconstructible
+from django.utils.translation import gettext_lazy as _
+
+
+@deconstructible
+class ProhibitNullCharactersValidator:
+    """Validate that the string doesn't contain the null character."""
+    message = _('Null characters are not allowed.')
+    code = 'null_characters_not_allowed'
+
+    def __init__(self, message=None, code=None):
+        if message is not None:
+            self.message = message
+        if code is not None:
+            self.code = code
+
+    def __call__(self, value):
+        if '\x00' in str(value):
+            raise ValidationError(self.message, code=self.code)
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, self.__class__) and
+            self.message == other.message and
+            self.code == other.code
+        )

--- a/{{cookiecutter.project_slug}}/apps/core/validators.py
+++ b/{{cookiecutter.project_slug}}/apps/core/validators.py
@@ -21,7 +21,6 @@ class ProhibitNullCharactersValidator:
 
     def __eq__(self, other):
         return (
-            isinstance(other, self.__class__) and
-            self.message == other.message and
+            isinstance(other, self.__class__) and self.message == other.message and
             self.code == other.code
         )

--- a/{{cookiecutter.project_slug}}/manage.py
+++ b/{{cookiecutter.project_slug}}/manage.py
@@ -4,7 +4,19 @@ import sys
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ cookiecutter.project_slug }}.settings.local")
-
-    from django.core.management import execute_from_command_line
-
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError:
+        # The above import may fail for some other reason. Ensure that the
+        # issue is really that Django is missing to avoid masking other
+        # exceptions on Python 2.
+        try:
+            import django
+        except ImportError:
+            raise ImportError(
+                "Couldn't import Django. Are you sure it's installed and "
+                "available on your PYTHONPATH environment variable? Did you "
+                "forget to activate a virtual environment?"
+            )
+        raise
     execute_from_command_line(sys.argv)

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -1,4 +1,4 @@
-Django==1.8.18
+Django==1.11.10
 pytz==2017.3
 pylibmc==1.5.2
 psycopg2==2.7.3.2

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -1,11 +1,11 @@
 Django==1.11.10
-pytz==2017.3
+pytz==2018.3
 pylibmc==1.5.2
 psycopg2==2.7.3.2
 Pillow==4.1.1
-olefile==0.44
+olefile==0.45.1
 dj-database-url==0.4.1
-raven==6.4.0
+raven==6.5.0
 
 # Storage
 django-storages==1.6.5
@@ -22,7 +22,7 @@ sorl-thumbnail==12.3
 # Glitter
 django-glitter==0.2.7
 django-mptt==0.9.0
-django-js-asset==0.1.1
+django-js-asset==1.0.0
 django-mptt-admin==0.5.0
 django-taggit==0.22.2
 python-dateutil==2.6.1

--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -1,7 +1,7 @@
 -r testing.txt
 
 django-debug-toolbar==1.9.1
-awscli==1.14.18
-ipdb==0.10.3
+awscli==1.14.42
+ipdb==0.11
 tox==2.9.1
 spectrum-python==0.9.8

--- a/{{cookiecutter.project_slug}}/requirements/testing.txt
+++ b/{{cookiecutter.project_slug}}/requirements/testing.txt
@@ -1,9 +1,9 @@
 -r base.txt
 
-django-extensions==1.9.8
+django-extensions==1.9.9
 flake8==3.5.0
 isort==4.2.15
-unittest-xml-reporting==2.1.0
-coverage==4.4.2
+unittest-xml-reporting==2.1.1
+coverage==4.5.1
 yapf==0.16.1
 pipdeptree==0.10.1

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -3,8 +3,8 @@ envlist = check, lint, tests
 skipsdist = true
 
 [testenv]
-basepython = python3.5
-envdir = {toxworkdir}/py35
+basepython = python3.6
+envdir = {toxworkdir}/py36
 deps =
     -rrequirements/base.txt
     -rrequirements/testing.txt

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/base.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/base.py
@@ -79,12 +79,11 @@ PROJECT_APPS = []
 
 INSTALLED_APPS = DEFAULT_APPS + THIRD_PARTY_APPS + PROJECT_APPS
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/base.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/base.py
@@ -194,6 +194,12 @@ LOGGING = {
             '()': 'django.utils.log.RequireDebugTrue',
         },
     },
+    'formatters': {
+        'django.server': {
+            '()': 'django.utils.log.ServerFormatter',
+            'format': '[%(server_time)s] %(message)s',
+        }
+    },
     'root': {
         'level': 'WARNING',
         'handlers': ['sentry'],
@@ -202,6 +208,11 @@ LOGGING = {
         'console': {
             'level': 'INFO',
             'filters': ['require_debug_true'],
+            'class': 'logging.StreamHandler',
+        },
+        'django.server': {
+            'level': 'INFO',
+            'formatter': 'django.server',
             'class': 'logging.StreamHandler',
         },
         'null': {
@@ -215,23 +226,29 @@ LOGGING = {
     'loggers': {
         'django': {
             'handlers': ['console'],
+            'level': 'INFO',
         },
         'django.db.backends': {
-            'level': 'ERROR',
             'handlers': ['console'],
+            'level': 'ERROR',
+            'propagate': False,
+        },
+        'django.server': {
+            'handlers': ['django.server'],
+            'level': 'INFO',
             'propagate': False,
         },
         'py.warnings': {
             'handlers': ['console'],
         },
         'raven': {
-            'level': 'DEBUG',
             'handlers': ['console'],
+            'level': 'DEBUG',
             'propagate': False,
         },
         'sentry.errors': {
-            'level': 'DEBUG',
             'handlers': ['console'],
+            'level': 'DEBUG',
             'propagate': False,
         },
     },

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/local.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/local.py
@@ -54,9 +54,9 @@ if not os.environ.get('DISABLE_TOOLBAR'):
         'debug_toolbar',
     ]
 
-    MIDDLEWARE_CLASSES = [
+    MIDDLEWARE = [
         'debug_toolbar.middleware.DebugToolbarMiddleware',
-    ] + MIDDLEWARE_CLASSES
+    ] + MIDDLEWARE
 
 # Only enable spectrum logging if requested, as the spectrum app needs to be loaded
 if os.environ.get('SPECTRUM'):

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/migrations.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/migrations.py
@@ -1,0 +1,7 @@
+from .base import *  # noqa
+
+# makemigrations --check requires a database if DATABASES is populated, but works fine without, so
+# we set this to an empty dict to stop makemigrations connecting to a database which doesn't exist
+DATABASES = {}
+
+SECRET_KEY = '{{ cookiecutter.project_slug }}'

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/production.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/production.py
@@ -21,6 +21,14 @@ TEMPLATES[0]['OPTIONS']['loaders'] = [
 CSRF_COOKIE_SECURE = True
 SESSION_COOKIE_SECURE = True
 
+# Improve password security to a reasonable bare minimum
+AUTH_PASSWORD_VALIDATORS = [
+    {'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator'},
+    {'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator'},
+    {'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator'},
+    {'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator'},
+]
+
 # Add more raven data to help diagnose bugs
 RAVEN_CONFIG = {
     'release': raven.fetch_git_sha(BASE_DIR),

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/tox.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/tox.py
@@ -1,3 +1,7 @@
+import warnings
+
+from django.utils.deprecation import RemovedInDjango21Warning
+
 import dj_database_url
 
 from .base import *  # noqa
@@ -28,3 +32,11 @@ INSTALLED_APPS += [
 # - Output these to a separate directory to avoid clutter
 TEST_RUNNER = 'xmlrunner.extra.djangotestrunner.XMLTestRunner'
 TEST_OUTPUT_DIR = 'reports'
+
+# Always error out on any warnings in loader_tags during testing with tox. This should highlight
+# any problems with include tags missing templates.
+warnings.filterwarnings(
+    'error',
+    category=RemovedInDjango21Warning,
+    module=r'^django\.template\.loader_tags$',
+)

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/urls.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/urls.py
@@ -15,7 +15,7 @@ admin.site.site_title = '{{ cookiecutter.project_name }}'
 admin.site.site_header = '{{ cookiecutter.project_name }}'
 
 urlpatterns = [
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
 {%- if cookiecutter.glitter == 'y' %}
     url(r'^blockadmin/', include(blocks.site.urls)),
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/urls.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/urls.py
@@ -26,7 +26,7 @@ if settings.DEBUG:
     from django.views.defaults import page_not_found
 
     urlpatterns += [
-        url(r'^404/$', page_not_found),
+        url(r'^404/$', page_not_found, {'exception': None}),
     ]
 
 # Only enable debug toolbar if it's an installed app

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/urls.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/urls.py
@@ -5,7 +5,7 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.http import HttpResponseServerError
-from django.template import Context, TemplateDoesNotExist, loader
+from django.template import TemplateDoesNotExist, loader
 {%- if cookiecutter.glitter == 'y' %}
 
 from glitter.blockadmin import blocks
@@ -48,6 +48,6 @@ def handler500(request, template_name='500.html'):
         template = loader.get_template(template_name)
     except TemplateDoesNotExist:
         return HttpResponseServerError('<h1>Server Error (500)</h1>', content_type='text/html')
-    return HttpResponseServerError(template.render(Context({
+    return HttpResponseServerError(template.render({
         'request': request,
-    })))
+    }))


### PR DESCRIPTION
Updates our template to support Django 1.11.

Sadly glitter doesn't support it just yet - however I'm keeping the option for that open, however the only choice for that is "n" in the cookiecutter settings.