### PR TITLE
Use full app names for INSTALLED_APPS

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/base.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/base.py
@@ -40,15 +40,15 @@ DEFAULT_APPS = [
     # These apps should come first to load correctly.
     'blanc_admin_theme',
     'core',
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'django.contrib.sites',
+    'django.contrib.admin.apps.AdminConfig',
+    'django.contrib.auth.apps.AuthConfig',
+    'django.contrib.contenttypes.apps.ContentTypesConfig',
+    'django.contrib.sessions.apps.SessionsConfig',
+    'django.contrib.messages.apps.MessagesConfig',
+    'django.contrib.staticfiles.apps.StaticFilesConfig',
+    'django.contrib.sites.apps.SitesConfig',
 {%- if cookiecutter.geodjango == 'y' %}
-    'django.contrib.gis',
+    'django.contrib.gis.apps.GISConfig',
 {%- endif %}
 ]
 
@@ -63,7 +63,7 @@ THIRD_PARTY_APPS = [
     'glitter.pages',
     'mptt',
 {%- endif %}
-    'raven.contrib.django.raven_compat',
+    'raven.contrib.django.apps.RavenConfig',
 {%- if cookiecutter.glitter == 'y' %}
     'sorl.thumbnail',
     'taggit',


### PR DESCRIPTION
Technically not necessary, however to encourage best practice with app names - let's use the full Config name for each app.

I've ignored the glitter apps as we'll be doing a PR to remove that at some point!