### PR TITLE
Only /reports not apps with the same name ignored

### DIFF
--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -8,7 +8,7 @@
 .coverage
 .tox
 htmlcov
-reports
+/reports/
 
 # NodeJS
 /node_modules


### PR DESCRIPTION
This is so that people don't get confused when they add an app called reports and it is not added in the commit.