### PR TITLE
Use environment variables for static and media files

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/base.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/base.py
@@ -150,7 +150,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/{{ cookiecutter.django_version }}/howto/static-files/
 
-STATIC_URL = '/static/'
+STATIC_URL = os.environ.get('STATIC_URL', '/static/')
 
 STATIC_ROOT = os.path.join(BASE_DIR, 'htdocs/static')
 
@@ -161,7 +161,7 @@ STATICFILES_DIRS = (os.path.join(BASE_DIR, 'static'),)
 # File uploads
 # https://docs.djangoproject.com/en/{{ cookiecutter.django_version }}/ref/settings/#file-uploads
 
-MEDIA_URL = '/media/'
+MEDIA_URL = os.environ.get('MEDIA_URL', '/media/')
 
 MEDIA_ROOT = os.path.join(BASE_DIR, 'htdocs/media')
 


### PR DESCRIPTION
Surprised it took us so long to find this as an issue, but `{{ MEDIA_URL }}` in templates would still return `/media/`.