### PR TITLE
Add BASE_URL for wagtail projects

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/base.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/base.py
@@ -250,6 +250,7 @@ CSRF_COOKIE_HTTPONLY = True
 
 # Wagtail
 WAGTAIL_SITE_NAME = "{{ cookiecutter.project_name }}"
+BASE_URL = os.environ.get("WAGTAIL_BASE_URL", "")
 WAGTAIL_ENABLE_UPDATE_CHECK = False
 WAGTAILSEARCH_BACKENDS = {
     "default": {


### PR DESCRIPTION
This is needed for outgoing emails, where request isn't available.

Really wish we didn't need it, as life would be a lot easier without it!