### PR TITLE
Actually register new deploy with sentry

### DIFF
--- a/{{cookiecutter.project_slug}}/fabfile.py
+++ b/{{cookiecutter.project_slug}}/fabfile.py
@@ -171,6 +171,9 @@ def sentry_release():
             project=env.repo, version=version
         ))
         run('sentry-cli releases set-commits --auto {version}'.format(version=version))
+        run('sentry-cli releases deploys {version} new --env $SENTRY_ENVIRONMENT'.format(
+            version=version
+        ))
 
 
 @task
@@ -251,7 +254,7 @@ def get_env():
     """ Get the current environment variables, ready for local export."""
     env.output_prefix = False
     run('export | sed -e "s/declare -x/export/g"')
-    
+
 
 @task
 def ssh(index='1'):


### PR DESCRIPTION
Apparently we've been sending data to Sentry, but missing the final step: https://docs.sentry.io/workflow/releases/?platform=python#create-deploy

We need to tell Sentry we've deployed the new version!