### PR TITLE
Fix regex for hiphenated-commands in help-display

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -210,4 +210,4 @@ pipdeptree-check:
 
 # Help
 help-display:
-	@awk '/^[[:alnum:]-]*: ##/ { split($$0, x, "##"); printf "%20s%s\n", x[1], x[2]; }' $(MAKEFILE_LIST)
+	@awk '/^[\-[:alnum:]]*: ##/ { split($$0, x, "##"); printf "%20s%s\n", x[1], x[2]; }' $(MAKEFILE_LIST)


### PR DESCRIPTION
notably `test-report` in this template, but some others in other repos.