### PR TITLE
Missing ' && ' from fabfile npm update command to join commands.

### DIFF
--- a/{{cookiecutter.project_slug}}/fabfile.py
+++ b/{{cookiecutter.project_slug}}/fabfile.py
@@ -117,10 +117,13 @@ def update():
         # Install nvm using .nvmrc version
         run('nvm install --no-progress')
 
+        # Initially create node_modules directory so copying .nvmrc and .package-lock.json work.
+        run('test -d node_modules || mkdir node_modules')
+
         # Check for changes in nvm version and copy to node_modules for future checks
         run(
             'cmp --silent .nvmrc node_modules/.nvmrc || '
-            'rm node_modules/.package-lock.json && '
+            'rm -f node_modules/.package-lock.json && '
             'cp -a .nvmrc node_modules/.nvmrc'
         )
 

--- a/{{cookiecutter.project_slug}}/fabfile.py
+++ b/{{cookiecutter.project_slug}}/fabfile.py
@@ -120,7 +120,7 @@ def update():
         # Check for changes in nvm version and copy to node_modules for future checks
         run(
             'cmp --silent .nvmrc node_modules/.nvmrc || '
-            'rm node_modules/.package-lock.json'
+            'rm node_modules/.package-lock.json && '
             'cp -a .nvmrc node_modules/.nvmrc'
         )
 

--- a/{{cookiecutter.project_slug}}/fabfile.py
+++ b/{{cookiecutter.project_slug}}/fabfile.py
@@ -111,27 +111,24 @@ def update():
         # Save the current git commit for Sentry release tracking
         run('git rev-parse HEAD > .sentry-release')
 
-        # Install python/node packages
+        # Install python packages
         run('pip install --quiet --requirement requirements/production.txt')
 
         # Install nvm using .nvmrc version
         run('nvm install --no-progress')
 
-        # Initially create node_modules directory so copying .nvmrc and .package-lock.json work.
-        run('test -d node_modules || mkdir node_modules')
-
         # Check for changes in nvm version and copy to node_modules for future checks
         run(
             'cmp --silent .nvmrc node_modules/.nvmrc || '
-            'rm -f node_modules/.package-lock.json && '
-            'cp -a .nvmrc node_modules/.nvmrc'
+            'rm -f node_modules/.package-lock.json'
         )
 
         # Install node packages
         run(
             'cmp --silent package-lock.json node_modules/.package-lock.json || '
             'npm ci --no-progress && '
-            'cp -a package-lock.json node_modules/.package-lock.json'
+            'cp -a package-lock.json node_modules/.package-lock.json && '
+            'cp -a .nvmrc node_modules/.nvmrc'
         )
 
         # Clean up any potential cruft


### PR DESCRIPTION
# Description

the `update` command fails, as there was a missing ` && ` joining 2 bash commands together, so the two lines were being concatinated into a single command, additionally since initially the `node_modules` directory doesn't exist, `cp` and `rm` into there fails, so create an empty directory.