### PR TITLE
Tell eslint to use prettier style switch() indentation.

### DIFF
--- a/{{cookiecutter.project_slug}}/.eslintrc.js
+++ b/{{cookiecutter.project_slug}}/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
     extends: ['airbnb-base', 'plugin:prettier/recommended'],
     rules: {
-        indent: ['error', 4],
+        indent: ['error', 4, {SwitchCase: 1}],
         camelcase: [0],
         'one-var': [0],
         'no-new': [0],

--- a/{{cookiecutter.project_slug}}/.eslintrc.js
+++ b/{{cookiecutter.project_slug}}/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
     extends: ['airbnb-base', 'plugin:prettier/recommended'],
     rules: {
-        indent: ['error', 4, {SwitchCase: 1}],
+        indent: ['error', 4, { SwitchCase: 1 }],
         camelcase: [0],
         'one-var': [0],
         'no-new': [0],


### PR DESCRIPTION
# Sources
https://github.com/developersociety/nightlinedashboard/pull/15
https://eslint.org/docs/rules/indent

# Description
prettier formats `switch` like:
```js
switch(thing) {
    case foo:
        doFoo()
        break;
...
```
indenting `case` and the block, this tells eslint to use that style too.