### PR TITLE
Bump up DATA_UPLOAD_MAX_NUMBER_FIELDS

### DIFF
--- a/{{cookiecutter.project_slug}}/project/settings/base.py
+++ b/{{cookiecutter.project_slug}}/project/settings/base.py
@@ -275,6 +275,9 @@ WAGTAILSEARCH_BACKENDS = {
         "INDEX": os.environ.get("SEARCH_INDEX", "{{ cookiecutter.project_slug }}"),
     }
 }
+
+# Django limits POST fields to 1,000 by default, however for Wagtail admin pages this is too low
+DATA_UPLOAD_MAX_NUMBER_FIELDS = 10000
 {%- endif %}
 {%- if cookiecutter.geodjango == 'y' %}
 


### PR DESCRIPTION
For Wagtail sites only - as this has happened quite frequently on Wagtail admin pages, but less so on standard Django sites.
