### PR TITLE
Add 2FA as standard for Wagtail sites

### DIFF
--- a/{{cookiecutter.project_slug}}/project/settings/base.py
+++ b/{{cookiecutter.project_slug}}/project/settings/base.py
@@ -63,10 +63,13 @@ DEFAULT_APPS = [
 
 THIRD_PARTY_APPS = [
     "crispy_forms",
+    "django_otp",
+    "django_otp.plugins.otp_totp",
     "maskpostgresdata",
     "modelcluster",
     "rest_framework",
     "taggit",
+    "wagtail_2fa",
     "wagtail.admin",
     "wagtail.contrib.forms",
     "wagtail.contrib.modeladmin",
@@ -103,6 +106,9 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+{%- if cookiecutter.wagtail == 'y' %}
+    "wagtail_2fa.middleware.VerifyUserMiddleware",
+{%- endif %}
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django.middleware.security.SecurityMiddleware",

--- a/{{cookiecutter.project_slug}}/project/settings/demo.py
+++ b/{{cookiecutter.project_slug}}/project/settings/demo.py
@@ -3,3 +3,6 @@ from .production import *  # noqa
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 DEMO_SITE = True
+
+# Wagtail site name is used for 2FA, so give the demo site a unique name
+WAGTAIL_SITE_NAME = f"{WAGTAIL_SITE_NAME} (demo)"

--- a/{{cookiecutter.project_slug}}/project/settings/production.py
+++ b/{{cookiecutter.project_slug}}/project/settings/production.py
@@ -62,3 +62,9 @@ if os.environ.get("ELASTIC_APM_SERVER_URL"):
 
 # Cache backed sessions for optimum performance
 SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
+{%- if cookiecutter.wagtail == 'y' %}
+
+# For convenience, 2FA is optional - this is False by default for most sites
+# If this is True, then 2FA is required for staff users (but this will not impact end users)
+WAGTAIL_2FA_REQUIRED = False
+{%- endif %}

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -26,7 +26,7 @@ django-crispy-forms==1.9.0
 {%- if cookiecutter.wagtail == 'y' %}
 
 # Wagtail (core wagtail)
-wagtail==2.7.1
+wagtail==2.7.3
 beautifulsoup4==4.6.0
 django-modelcluster==5.0.1
 django-taggit==1.2.0

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -49,10 +49,15 @@ wagtailfontawesome==1.2.1
 
 # Wagtail search
 elasticsearch==6.4.0
+
+# Wagtail 2FA
+django-otp==0.9.1
+qrcode==6.1
+wagtail-2fa==1.4.2
 {%- endif %}
 
-
 {%- if cookiecutter.multilingual == 'y' %}
+
 # Translations
 translate-toolkit==2.3.1
 diff-match-patch==20121119


### PR DESCRIPTION
To test:

```
mktmpenv
cookiecutter -c wagtail-2fa gh:developersociety/django-template wagtail=y
cd projectname
nvm use
make npm-install pip-install-local
dropdb --if-exists projectname_django
createdb projectname_django
./manage.py migrate
make django-dev-createsuperuser
./manage.py runserver
```

You should be able to go into the Wagtail admin and add a 2FA device - not required for local development.

I've intentionally set 2FA to not be required in production.py - if a partner wants their site to be enforced 2FA, all we have to do is change that to `True` and our job is done!