### PR TITLE
add readonly panel to wagtail project

### DIFF
--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -58,6 +58,7 @@ elif [ "$WAGTAIL" == "n" ] && [ "$MULTILINGUAL" == "y" ]; then
     # remove any wagtail related files
     # No wagtail - remove any wagtail related files
     rm -f apps/core/monkeypatch.py
+    rm -f apps/core/edit_handlers.py
     rm -rf apps/pages
     rm -rf apps/settings
     rm -rf templates/blocks
@@ -84,6 +85,7 @@ else
 
     # No wagtail - remove any wagtail related files
     rm -f apps/core/monkeypatch.py
+    rm -f apps/core/edit_handlers.py
     rm -rf apps/pages
     rm -rf apps/settings
     rm -rf templates/blocks

--- a/{{cookiecutter.project_slug}}/apps/core/edit_handlers.py
+++ b/{{cookiecutter.project_slug}}/apps/core/edit_handlers.py
@@ -1,0 +1,46 @@
+from django.utils.html import format_html
+
+from wagtail.admin.edit_handlers import EditHandler
+
+
+class ReadOnlyFieldPanel(EditHandler):
+    def __init__(self, attr, *args, **kwargs):
+        self.attr = attr
+        super().__init__(*args, **kwargs)
+
+    def clone(self):
+        return self.__class__(
+            attr=self.attr,
+            heading=self.heading,
+            classname=self.classname,
+            help_text=self.help_text,
+        )
+
+    def _get_value(self):
+        value = getattr(self.instance, self.attr)
+        is_callable = callable(value)
+        if is_callable:
+            value = value()
+        return value
+
+    def render(self):
+        return format_html('<div style="padding-top: 1.2em;">{}</div>', self._get_value())
+
+    def render_as_object(self):
+        return format_html(
+            f"""
+            <fieldset><legend>{self.heading}</legend>
+            <ul class="fields"><li><div class="field">{self.render()}</div></li></ul>
+            </fieldset>
+            """
+        )
+
+    def render_as_field(self):
+        return format_html(
+            f"""
+            <div class="field">
+            <label>{self.heading}:</label>
+            <div class="field-content">{self.render()}</div>
+            </div>
+            """
+        )


### PR DESCRIPTION
Sources
Include links to cards and Sentry errors here.

Description
Realised working on BHRRC that there's no `Readonly` panel for wagtail, seems like a useful thing to have so this just adds it to the template.
Setup instructions
- pull this branch

How to test
- create a new wagtail project
- add a field to a page model
- in the `panels` set add a readonly panel for the field you added
- go to the admin for that page and see the readonly field.

Happy to close this PR if it's not needed, seemed like it could be useful though. It was used in BHRRC for imported IDs that shouldn't be changed, but are useful to see in the admin.