### PR TITLE
Remove the Django admin on Wagtail sites

### DIFF
--- a/{{cookiecutter.project_slug}}/project/settings/base.py
+++ b/{{cookiecutter.project_slug}}/project/settings/base.py
@@ -44,7 +44,9 @@ sys.path.append(PROJECT_APPS_ROOT)
 DEFAULT_APPS = [
     # These apps should come first to load correctly.
     "core.apps.CoreConfig",
+{%- if cookiecutter.wagtail != 'y' %}
     "django.contrib.admin.apps.AdminConfig",
+{%- endif %}
     "django.contrib.auth.apps.AuthConfig",
     "django.contrib.contenttypes.apps.ContentTypesConfig",
     "django.contrib.sessions.apps.SessionsConfig",

--- a/{{cookiecutter.project_slug}}/project/urls.py
+++ b/{{cookiecutter.project_slug}}/project/urls.py
@@ -4,7 +4,9 @@ from django.conf import settings
 from django.conf.urls.i18n import i18n_patterns
 {%- endif %}
 from django.conf.urls.static import static
+{%- if cookiecutter.wagtail != "y" %}
 from django.contrib import admin
+{%- endif %}
 from django.contrib.staticfiles.views import serve as staticfiles_serve
 from django.urls import include, path
 from django.views.decorators.cache import never_cache
@@ -21,8 +23,12 @@ from wagtail.documents import urls as wagtaildocs_urls
 
 from core.views import server_error
 
+{%- if cookiecutter.wagtail != "y" %}
+
 admin.site.site_title = "{{ cookiecutter.project_name }}"
 admin.site.site_header = "{{ cookiecutter.project_name }}"
+
+{%- endif %}
 
 handler500 = server_error
 
@@ -31,7 +37,6 @@ handler500 = server_error
 # Multilingual Wagtail site
 
 urlpatterns = [
-    path("django-admin/", admin.site.urls),
     path("admin/", include(wagtailadmin_urls)),
     path("documents/", include(wagtaildocs_urls)),
     path("sitemap.xml", sitemap, name="sitemap"),
@@ -45,7 +50,6 @@ urlpatterns += i18n_patterns(path(r"", include(wagtail_urls)))
 # Standard Wagtail site
 
 urlpatterns = [
-    path("django-admin/", admin.site.urls),
     path("admin/", include(wagtailadmin_urls)),
     path("documents/", include(wagtaildocs_urls)),
     path("sitemap.xml", sitemap, name="sitemap"),


### PR DESCRIPTION
We've done this on our main site already.

It's been low priority, but it's now time!

To test:

```
mktmpenv
cookiecutter --no-input --checkout wagtail-no-django-admin gh:developersociety/django-template wagtail=y
cd projectname
nvm use
make npm-install pip-install-local
dropdb --if-exists projectname_django
createdb projectname_django
./manage.py migrate
make django-dev-createsuperuser
./manage.py runserver
```

And http://127.0.0.1:8000/django-admin/ should 404!