### PR TITLE
Add django-axes by default to all projects

### DIFF
--- a/{{cookiecutter.project_slug}}/project/settings/base.py
+++ b/{{cookiecutter.project_slug}}/project/settings/base.py
@@ -10,6 +10,7 @@ https://docs.djangoproject.com/en/{{ cookiecutter.django_version }}/ref/settings
 
 import os
 import sys
+from datetime import timedelta
 
 {%- if cookiecutter.multilingual == 'y' %}
 
@@ -64,6 +65,7 @@ DEFAULT_APPS = [
 {%- if cookiecutter.wagtail == 'y' %}
 
 THIRD_PARTY_APPS = [
+    "axes",
     "crispy_forms",
     "django_otp",
     "django_otp.plugins.otp_totp",
@@ -91,7 +93,7 @@ THIRD_PARTY_APPS = [
 ]
 {%- else %}
 
-THIRD_PARTY_APPS = ["crispy_forms", "maskpostgresdata"]
+THIRD_PARTY_APPS = ["axes", "crispy_forms", "maskpostgresdata"]
 {%- endif %}
 {%- if cookiecutter.wagtail == 'y' %}
 
@@ -123,6 +125,7 @@ MIDDLEWARE = [
 {%- else %}
     "django.contrib.sites.middleware.CurrentSiteMiddleware",
 {%- endif %}
+    "axes.middleware.AxesMiddleware",
 ]
 
 ROOT_URLCONF = "project.urls"
@@ -270,6 +273,18 @@ CONTENTFILES_S3_ENDPOINT = os.environ.get("CONTENTFILES_S3_ENDPOINT")
 
 # Improved cookie security
 CSRF_COOKIE_HTTPONLY = True
+
+# Improved login security with axes
+# - Only lock attempts by username (prevent mass attempts on single accounts)
+# - 10 failures in 15 attempts results in blocking
+AUTHENTICATION_BACKENDS = [
+    "axes.backends.AxesBackend",
+    "django.contrib.auth.backends.ModelBackend",
+]
+AXES_ONLY_USER_FAILURES = True
+AXES_FAILURE_LIMIT = 10
+AXES_COOLOFF_TIME = timedelta(minutes=15)
+AXES_ENABLE_ADMIN = False
 {%- if cookiecutter.wagtail == 'y' %}
 
 # Wagtail

--- a/{{cookiecutter.project_slug}}/project/settings/local.py
+++ b/{{cookiecutter.project_slug}}/project/settings/local.py
@@ -50,6 +50,9 @@ PASSWORD_HASHERS = [
     "django.contrib.auth.hashers.CryptPasswordHasher",
     "django.contrib.auth.hashers.PBKDF2PasswordHasher",
 ]
+
+# Disable axes for local usage
+AXES_ENABLED = False
 {%- if cookiecutter.wagtail == 'y' %}
 
 # Wagtail search - use Postgres unless ENABLE_ELASTICSEARCH is enabled with environment vars

--- a/{{cookiecutter.project_slug}}/project/settings/tox.py
+++ b/{{cookiecutter.project_slug}}/project/settings/tox.py
@@ -26,6 +26,9 @@ TEST_OUTPUT_DIR = "reports"
 
 # Always run tests with the fastest password hasher
 PASSWORD_HASHERS = ["django.contrib.auth.hashers.CryptPasswordHasher"]
+
+# Disable axes during testing
+AXES_ENABLED = False
 {%- if cookiecutter.wagtail == 'y' %}
 
 # Avoid wagtail search updates during testing

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -21,6 +21,11 @@ sentry-sdk==0.14.3
 urllib3==1.25.8
 certifi==2019.11.28
 
+# Axes
+django-axes==5.3.2
+django-appconf==1.0.4
+django-ipware==2.1.0
+
 # Form styling
 django-crispy-forms==1.9.0
 {%- if cookiecutter.wagtail == 'y' %}


### PR DESCRIPTION
Fairly relaxed settings - but these can easily be tweaked for projects which require a higher level of security

To test:

```
mktmpenv
cookiecutter --no-input --checkout axes gh:developersociety/django-template
cd projectname
nvm use
make npm-install pip-install-local
dropdb --if-exists projectname_django
createdb projectname_django
./manage.py migrate
make django-dev-createsuperuser
./manage.py runserver
```

And you'll see axes in the migrations.

If you really want to verify it can work in production, set `AXES_ENABLED = True` in local.py and try and fail login a bunch of times - you'll be locked out.