### PR TITLE
Package upgrades for July 2020

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skipsdist = true
 basepython = python3.8
 envdir = {toxworkdir}/py38
 deps =
-    cookiecutter==1.7.0
+    cookiecutter==1.7.2
 changedir = {envtmpdir}
 whitelist_externals =
     bash

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -1,8 +1,8 @@
-Django==2.2.13
-pytz==2019.3
+Django==2.2.14
+pytz==2020.1
 pylibmc==1.6.1
-psycopg2==2.8.4
-Pillow==6.2.2
+psycopg2==2.8.5
+Pillow==7.2.0
 olefile==0.46
 dj-database-url==0.5.0
 sqlparse==0.3.1
@@ -13,8 +13,8 @@ django-maskpostgresdata==0.1.12
 # Storage
 devsoc-contentfiles==0.3
 django-storages==1.9.1
-boto3==1.14.0
-botocore==1.17.0
+boto3==1.14.23
+botocore==1.17.23
 docutils==0.15.2
 jmespath==0.10.0
 python-dateutil==2.8.1
@@ -23,35 +23,35 @@ six==1.15.0
 urllib3==1.25.9
 
 # Reporting (Errors, APM)
-elastic-apm==5.5.2
-sentry-sdk==0.14.3
-certifi==2019.11.28
+elastic-apm==5.8.1
+sentry-sdk==0.16.1
+certifi==2020.6.20
 
 # Axes
-django-axes==5.3.2
+django-axes==5.4.1
 django-appconf==1.0.4
-django-ipware==2.1.0
+django-ipware==3.0.0
 
 # Form styling
-django-crispy-forms==1.9.0
+django-crispy-forms==1.9.2
 {%- if cookiecutter.wagtail == 'y' %}
 
 # Wagtail (core wagtail)
-wagtail==2.7.3
+wagtail==2.7.4
 beautifulsoup4==4.6.0
-django-modelcluster==5.0.1
-django-taggit==1.2.0
+django-modelcluster==5.0.2
+django-taggit==1.3.0
 django-treebeard==4.3.1
 djangorestframework==3.11.0
 draftjs-exporter==2.1.7
-html5lib==1.0.1
+html5lib==1.1
 Unidecode==1.1.1
 webencodings==0.5.1
 Willow==1.3
 
 # Requests (wagtail)
-requests==2.23.0
-idna==2.9
+requests==2.24.0
+idna==2.10
 chardet==3.0.4
 
 # Wagtail extras
@@ -61,7 +61,7 @@ wagtailfontawesome==1.2.1
 elasticsearch==6.4.0
 
 # Wagtail 2FA
-django-otp==0.9.1
+django-otp==0.9.3
 qrcode==6.1
 wagtail-2fa==1.4.2
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -1,7 +1,7 @@
 -r testing.txt
 
-awscli==1.18.77
+awscli==1.18.100
 django-debug-toolbar==2.2
-ipdb==0.13.2
+ipdb==0.13.3
 pywatchman==1.4.1
-tox==3.14.6
+tox==3.17.1

--- a/{{cookiecutter.project_slug}}/requirements/testing.txt
+++ b/{{cookiecutter.project_slug}}/requirements/testing.txt
@@ -1,10 +1,10 @@
 -r base.txt
 
 black==19.10b0
-coverage==5.0.4
-django-extensions==2.2.9
-flake8==3.7.9
+coverage==5.2
+django-extensions==3.0.3
+flake8==3.8.3
 isort==4.3.21
-pipdeptree==0.13.2
+pipdeptree==1.0.0
 factory-boy==2.12.0
 unittest-xml-reporting==3.0.2


### PR DESCRIPTION
New security release for Wagtail, bugfix update for Django. Updating all the other easy things while I'm on it.

If you'd like to test one locally:

```
mktmpenv
cookiecutter --no-input --checkout package-upgrades gh:developersociety/django-template wagtail=y
cd projectname
nvm use
make npm-install pip-install-local
dropdb --if-exists projectname_django
createdb projectname_django
./manage.py migrate
make django-dev-createsuperuser
./manage.py runserver
```