### PR TITLE
Fix fab translations

### DIFF
--- a/{{cookiecutter.project_slug}}/fabfile.py
+++ b/{{cookiecutter.project_slug}}/fabfile.py
@@ -166,13 +166,15 @@ def static():
         run('python manage.py collectstatic --verbosity=0 --noinput')
 
 {%- if cookiecutter.multilingual == 'y' %}
+
+
 @task
 @roles('web')
 @parallel
 def translations():
     """ Update translation files. """
-    with cd(env.home):
-        run('make translations')
+    with cd(env.home), cd('locale'):
+        run('python ../manage.py compilemessages --verbosity=0')
 {%- endif %}
 
 


### PR DESCRIPTION
make translations was intended as a local command for the development process, updating translation files, etc - not for deployment.

To test:

```
mktmpenv
cookiecutter --no-input --checkout fab-translations gh:developersociety/django-template multilingual=y
```

Check `project_name/fabfile.py` - will have the newer fab translations, and test with multilingual=n if you want.