### PR TITLE
Add mixin for cross-browser word breaking

### DIFF
--- a/{{cookiecutter.project_slug}}/static/src/scss/mixins/_common.scss
+++ b/{{cookiecutter.project_slug}}/static/src/scss/mixins/_common.scss
@@ -38,6 +38,22 @@
     padding: 0;
 }
 
+// Break long words across browsers
+// https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/
+@mixin break-word {
+    // These are technically the same, but use both
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+
+    // This is the dangerous one in WebKit, as it breaks things wherever
+    word-break: break-all;
+    // Instead use this non-standard one
+    word-break: break-word;
+
+    // Adds a hyphen where the word breaks, if supported (No Blink)
+    hyphens: auto;
+}
+
 .hidden {
     @include hidden;
 }
@@ -60,4 +76,8 @@
 
 .unstyled-list {
     @include unstyled-list;
+}
+
+.break-word {
+    @include break-word;
 }


### PR DESCRIPTION
### Sources
See related PR on ILC: https://github.com/developersociety/internationallandcoalition/pull/303

### Description
Turns out word breaking isn't as simple as I thought it was! There are different properties on Firefox and on Chrome. This adds a mixin based on a CSS tricks article (https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/) - I'm never going to remember this, so thought it best to put it in the template immediately as it's such a commonly used feature. 

### How to test
The easiest way to test the code would be to test it on the ILC PR (https://github.com/developersociety/internationallandcoalition/pull/303) and simply approve this one. Or you could set up a new project using the cookie cutter, add a very long word to a template and apply the class or the mixin!

For comprehensive guidelines on code review at DEV, see here: https://www.notion.so/developersociety/Code-Review-b6d646b1d6e54011ada8169aee543231.
