### PR TITLE
Leave django admin app enabled - wagtail admin needs it.

### DIFF
--- a/{{cookiecutter.project_slug}}/project/settings/base.py
+++ b/{{cookiecutter.project_slug}}/project/settings/base.py
@@ -45,9 +45,7 @@ sys.path.append(PROJECT_APPS_ROOT)
 DEFAULT_APPS = [
     # These apps should come first to load correctly.
     "core.apps.CoreConfig",
-{%- if cookiecutter.wagtail != 'y' %}
     "django.contrib.admin.apps.AdminConfig",
-{%- endif %}
     "django.contrib.auth.apps.AuthConfig",
     "django.contrib.contenttypes.apps.ContentTypesConfig",
     "django.contrib.sessions.apps.SessionsConfig",


### PR DESCRIPTION
# Sources
https://github.com/developersociety/resourcealliance/pull/47

# Description
The wagtail admin is dependent on static files from the django admin. (for svg ticks on boolean fields, etc).