### PR TITLE
Mostly template fixes

### DIFF
--- a/{{cookiecutter.project_slug}}/project/settings/base.py
+++ b/{{cookiecutter.project_slug}}/project/settings/base.py
@@ -14,7 +14,7 @@ from datetime import timedelta
 
 {%- if cookiecutter.multilingual == 'y' %}
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 {%- endif %}
 
 import dj_database_url

--- a/{{cookiecutter.project_slug}}/templates/base.html
+++ b/{{cookiecutter.project_slug}}/templates/base.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-{% load staticfiles %}
+{% load static %}
 
 <html lang="en">
   <head>

--- a/{{cookiecutter.project_slug}}/templates/base.html
+++ b/{{cookiecutter.project_slug}}/templates/base.html
@@ -8,7 +8,7 @@
       {% block title %}{{ request.site.name }}{% endblock %}
     </title>
     <link rel="stylesheet" href="{% static 'dist/css/styles.css' %}">
-    <link rel="canonical" href="{{ request.scheme }}://{{ request.get_host }}" />
+    <link rel="canonical" href="{{ request.build_absolute_uri }}" />
 
     {% include 'includes/meta.html' %}
 

--- a/{{cookiecutter.project_slug}}/templates/base_multilingual.html
+++ b/{{cookiecutter.project_slug}}/templates/base_multilingual.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-{% load staticfiles %}
+{% load static %}
 {% load i18n %}
 
 <html lang="{{ LANGUAGE_CODE }}" {% if LANGUAGE_BIDI %}dir="rtl"{% endif %} >

--- a/{{cookiecutter.project_slug}}/templates/base_multilingual.html
+++ b/{{cookiecutter.project_slug}}/templates/base_multilingual.html
@@ -9,7 +9,7 @@
       {% block title %}{{ request.site.name }}{% endblock %}
     </title>
     <link rel="stylesheet" href="{% static 'dist/css/styles.css' %}">
-    <link rel="canonical" href="{{ request.scheme }}://{{ request.get_host }}" />
+    <link rel="canonical" href="{{ request.build_absolute_uri }}" />
 
     {% include 'includes/meta.html' %}
 

--- a/{{cookiecutter.project_slug}}/templates/base_wagtail.html
+++ b/{{cookiecutter.project_slug}}/templates/base_wagtail.html
@@ -12,7 +12,7 @@
       {% block title %}{{ site.site_name }}{% endblock %}
     </title>
     <link href="{% static 'dist/css/styles.css' %}" rel="stylesheet">
-    <link rel="canonical" href="{{ request.scheme }}://{{ request.get_host }}" />
+    <link rel="canonical" href="{{ request.build_absolute_uri }}" />
 
     {% include 'includes/meta.html' %}
 

--- a/{{cookiecutter.project_slug}}/templates/base_wagtail_multilingual.html
+++ b/{{cookiecutter.project_slug}}/templates/base_wagtail_multilingual.html
@@ -13,7 +13,7 @@
       {% block title %}{{ site.site_name }}{% endblock %}
     </title>
     <link href="{% static 'dist/css/styles.css' %}" rel="stylesheet">
-    <link rel="canonical" href="{{ request.scheme }}://{{ request.get_host }}" />
+    <link rel="canonical" href="{{ request.build_absolute_uri }}" />
 
     {% include 'includes/meta.html' %}
 

--- a/{{cookiecutter.project_slug}}/templates/includes/meta.html
+++ b/{{cookiecutter.project_slug}}/templates/includes/meta.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 
 <meta name="viewport" content="width=device-width,initial-scale=1">
 

--- a/{{cookiecutter.project_slug}}/templates/includes/meta_wagtail.html
+++ b/{{cookiecutter.project_slug}}/templates/includes/meta_wagtail.html
@@ -1,4 +1,5 @@
-{% load staticfiles wagtailimages_tags %}
+{% load static %}
+{% load wagtailimages_tags %}
 
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta itemprop="name" content="{{ site.site_name }}">


### PR DESCRIPTION
Minor issues:

- Django 4.0 needs a change load staticfiles to load static instead - this will reduce the size of future PRs
- Change ugettext to gettext - as we're not using Python 2 anymore, and is also removed in future Django versions
- Canonical URL is always pointing to the homepage 😮 - changing this to match og:url in meta.html

If you'd like to test locally:

```
mktmpenv
cookiecutter --no-input --checkout mostly-template-fixes gh:developersociety/django-template wagtail=y
cd projectname
nvm use
make npm-install pip-install-local
dropdb --if-exists projectname_django
createdb projectname_django
./manage.py migrate
make django-dev-createsuperuser
./manage.py runserver
```

If you go to: http://127.0.0.1:8000/?hello=world - the querystring will be in the canonical URL.

Note: maybe in another round we should determine the canonical URL to respect the actual page URL from Wagtail, however this is the faster fix for now.