### PR TITLE
Package upgrades

### DIFF
--- a/{{cookiecutter.project_slug}}/.isort.cfg
+++ b/{{cookiecutter.project_slug}}/.isort.cfg
@@ -2,9 +2,10 @@
 combine_as_imports = true
 sections = FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 known_django = django
+known_first_party = apps/
 include_trailing_comma = true
+float_to_top = true
 force_grid_wrap = 0
 line_length = 99
 multi_line_output = 3
-not_skip = __init__.py
 skip_glob = */migrations/*.py

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -104,10 +104,10 @@ fab-deploy:
 
 # ISort
 isort-lint:
-	isort --recursive --check-only --diff apps project
+	isort --check-only --diff apps project
 
 isort-format:
-	isort --recursive apps project
+	isort apps project
 
 
 # Flake8

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -1,36 +1,34 @@
-Django==2.2.14
-pytz==2020.1
+Django==2.2.17
+pytz==2020.4
 pylibmc==1.6.1
-psycopg2==2.8.5
+psycopg2==2.8.6
 Pillow==7.2.0
 olefile==0.46
 dj-database-url==0.5.0
-sqlparse==0.3.1
+sqlparse==0.4.1
 
 # Masked database backups
 django-maskpostgresdata==0.1.13
 
 # Storage
 devsoc-contentfiles==0.3
-django-storages==1.9.1
-boto3==1.14.23
-botocore==1.17.23
-docutils==0.15.2
+django-storages==1.10.1
+boto3==1.16.10
+botocore==1.19.10
 jmespath==0.10.0
 python-dateutil==2.8.1
 s3transfer==0.3.3
 six==1.15.0
-urllib3==1.25.9
+urllib3==1.25.11
 
 # Reporting (Errors, APM)
-elastic-apm==5.8.1
-sentry-sdk==0.16.1
+elastic-apm==5.9.0
+sentry-sdk==0.19.2
 certifi==2020.6.20
 
 # Axes
-django-axes==5.4.1
-django-appconf==1.0.4
-django-ipware==3.0.0
+django-axes==5.8.0
+django-ipware==3.0.1
 
 # Form styling
 django-crispy-forms==1.9.2
@@ -61,7 +59,7 @@ wagtailfontawesome==1.2.1
 elasticsearch==6.4.0
 
 # Wagtail 2FA
-django-otp==0.9.3
+django-otp==1.0.2
 qrcode==6.1
 wagtail-2fa==1.4.2
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -1,7 +1,7 @@
 -r testing.txt
 
-awscli==1.18.100
-django-debug-toolbar==2.2
-ipdb==0.13.3
+awscli==1.18.170
+django-debug-toolbar==3.1.1
+ipdb==0.13.4
 pywatchman==1.4.1
-tox==3.17.1
+tox==3.20.1

--- a/{{cookiecutter.project_slug}}/requirements/testing.txt
+++ b/{{cookiecutter.project_slug}}/requirements/testing.txt
@@ -4,7 +4,7 @@ black==20.8b1
 coverage==5.3
 django-extensions==3.0.9
 flake8==3.8.4
-isort==4.3.21
+isort==5.6.4
 pipdeptree==1.0.0
 factory-boy==3.1.0
 unittest-xml-reporting==3.0.4

--- a/{{cookiecutter.project_slug}}/requirements/testing.txt
+++ b/{{cookiecutter.project_slug}}/requirements/testing.txt
@@ -1,10 +1,10 @@
 -r base.txt
 
-black==19.10b0
-coverage==5.2
-django-extensions==3.0.3
-flake8==3.8.3
+black==20.8b1
+coverage==5.3
+django-extensions==3.0.9
+flake8==3.8.4
 isort==4.3.21
 pipdeptree==1.0.0
-factory-boy==2.12.0
-unittest-xml-reporting==3.0.2
+factory-boy==3.1.0
+unittest-xml-reporting==3.0.4


### PR DESCRIPTION
Nothing too exciting, however I'm leaving out Wagtail upgrades for another PR, and also isort will be a separate PR.

To test locally:

```
mktmpenv
cookiecutter --no-input --checkout package-upgrades-nov-2020 gh:developersociety/django-template wagtail=y
cd projectname
nvm use
make npm-install pip-install-local
dropdb --if-exists projectname_django
createdb projectname_django
./manage.py migrate
make django-dev-createsuperuser
./manage.py runserver
```