### PR TITLE
Add workaround for checks connecting to the database

### DIFF
--- a/{{cookiecutter.project_slug}}/project/settings/migrations.py
+++ b/{{cookiecutter.project_slug}}/project/settings/migrations.py
@@ -1,7 +1,15 @@
 from .base import *  # noqa
 
+{%- if cookiecutter.wagtail == 'y' %}
+
+# makemigrations --check requires a database starting with Wagtail 2.10, but we don't want to try
+# connecting to a real one - so use an in-memory sqlite one.
+DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}
+{%- else %}
+
 # makemigrations --check requires a database if DATABASES is populated, but works fine without, so
 # we set this to an empty dict to stop makemigrations connecting to a database which doesn't exist
 DATABASES = {}
+{%- endif %}
 
 SECRET_KEY = "secret"

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -35,14 +35,14 @@ django-crispy-forms==1.9.2
 {%- if cookiecutter.wagtail == 'y' %}
 
 # Wagtail (core wagtail)
-wagtail==2.11
+wagtail==2.11.1
 anyascii==0.1.7
 beautifulsoup4==4.8.2
 django-filter==2.4.0
 django-modelcluster==5.1
 django-taggit==1.3.0
 django-treebeard==4.3.1
-djangorestframework==3.12.1
+djangorestframework==3.12.2
 draftjs-exporter==2.1.7
 et-xmlfile==1.0.1
 html5lib==1.1


### PR DESCRIPTION
See https://github.com/developersociety/citizensuk/pull/12.

After investigating this to see if there's a fix to submit... it doesn't seem worth it. Unidecode is on the way out anyway: https://github.com/wagtail/wagtail/pull/6244#issuecomment-670611289

Hopefully we can revert this with the next Wagtail LTS release.