### PR TITLE
Switch to redis for caching, and user sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Install Ubuntu packages
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-            libgdal26 \
-            libmemcached-dev
+            libgdal26
       - name: Python pip cache
         uses: actions/cache@v2
         with:

--- a/{{cookiecutter.project_slug}}/fabfile.py
+++ b/{{cookiecutter.project_slug}}/fabfile.py
@@ -28,7 +28,6 @@ env.database = env.get('database', '{{ cookiecutter.project_slug }}_django')
 CRONTAB = """
 MAILTO=""
 
-{daily}         /usr/local/bin/django-cron python manage.py clearsessions
 {%- if cookiecutter.wagtail == 'y' %}
 {publish_schedule}  /usr/local/bin/django-cron python manage.py publish_scheduled_pages
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/project/settings/base.py
+++ b/{{cookiecutter.project_slug}}/project/settings/base.py
@@ -138,11 +138,11 @@ DATABASES = {"default": dj_database_url.config()}
 # https://docs.djangoproject.com/en/{{ cookiecutter.django_version }}/topics/cache/
 
 CACHES = {}
-if os.environ.get("MEMCACHED_SERVERS"):
+if os.environ.get("REDIS_SERVERS"):
     CACHES["default"] = {
-        "BACKEND": "django.core.cache.backends.memcached.PyLibMCCache",
-        "LOCATION": os.environ["MEMCACHED_SERVERS"].split(" "),
-        "KEY_PREFIX": os.environ.get("MEMCACHED_PREFIX"),
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": os.environ["REDIS_SERVERS"].split(" "),
+        "KEY_PREFIX": "{}:cache".format(os.environ["REDIS_PREFIX"]),
     }
 else:
     CACHES["default"] = {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}

--- a/{{cookiecutter.project_slug}}/project/settings/production.py
+++ b/{{cookiecutter.project_slug}}/project/settings/production.py
@@ -60,8 +60,9 @@ if os.environ.get("ELASTIC_APM_SERVER_URL"):
 
     MIDDLEWARE = ["elasticapm.contrib.django.middleware.TracingMiddleware"] + MIDDLEWARE
 
-# Cache backed sessions for optimum performance
-SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
+# Cache sessions for optimum performance
+if os.environ.get("REDIS_SERVERS"):
+    SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 {%- if cookiecutter.wagtail == 'y' %}
 
 # For convenience, 2FA is optional - this is False by default for most sites

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -1,11 +1,14 @@
 Django==2.2.17
 pytz==2020.4
-pylibmc==1.6.1
 psycopg2==2.8.6
 Pillow==8.0.1
 olefile==0.46
 dj-database-url==0.5.0
 sqlparse==0.4.1
+
+# Caching
+django-redis==4.12.1
+redis==3.5.3
 
 # Masked database backups
 django-maskpostgresdata==0.1.13


### PR DESCRIPTION
We've used this on one project, let's use it going forward. Advantages:

- It reduces writes to Postgres, every row we write for sessions increases the size of the WAL, which increases backups, makes a point in time recovery slower, etc.
- Removes session data from the database - when we're getting backups to test with
- Cache gets reloaded after restart
- Easier to purge part of the cache, which is more difficult with other backends
- Removes pylibmc as a dependency - it requires compilation, another package to be installed
- Removes a cron command from the vast majority of projects

To test:

In one window: `redis-server`

In another:

```
mktmpenv
cookiecutter --no-input --checkout redis gh:developersociety/django-template wagtail=y
cd projectname
nvm use
make npm-install pip-install-local
dropdb --if-exists projectname_django
createdb projectname_django
./manage.py migrate
make django-dev-createsuperuser
REDIS_SERVERS=redis://127.0.0.1:6379 REDIS_PREFIX=demo ./manage.py runserver
```

Go to http://127.0.0.1:8000/admin/

And: `redis-cli keys '*'`