### PR TITLE
Setup GitHub Actions for actual projects

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,6 +6,7 @@
     "geodjango": "n",
     "wagtail": "n",
     "_copy_without_render": [
+        ".github/workflows/*.yml",
         "static",
         "templates/*.html"
     ]

--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
 set -e
 
+GEODJANGO="{{ cookiecutter.geodjango }}"
 WAGTAIL="{{ cookiecutter.wagtail }}"
 MULTILINGUAL="{{ cookiecutter.multilingual }}"
+
+if [ "$GEODJANGO" == "y" ]; then
+    mv .github/workflows/ci_geodjango.yml .github/workflows/ci.yml
+    rm .github/workflows/ci_standard.yml
+else
+    mv .github/workflows/ci_standard.yml .github/workflows/ci.yml
+    rm .github/workflows/ci_geodjango.yml
+fi
 
 if [ "$WAGTAIL" == "y" ] && [ "$MULTILINGUAL" == "y" ]; then
     # Wagtail requested with multilingual features

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci_geodjango.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci_geodjango.yml
@@ -1,0 +1,54 @@
+name: CI
+on: pull_request
+jobs:
+  test:
+    name: Test -- tox
+    runs-on: ubuntu-16.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Ubuntu packages
+        run: |
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            libgdal1i
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+      - name: Get Node.js version
+        id: nvmrc
+        run: echo "::set-output name=version::$(cat .nvmrc)"
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ steps.nvmrc.outputs.version }}
+      - name: Python pip cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements/*.txt') }}
+      - name: Node.js npm cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.npm
+            **/node_modules
+          key: ${{ runner.os }}-node-${{ steps.nvmrc.outputs.version }}-${{ hashFiles('package.json', 'package-lock.json') }}
+      - name: Run tests
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: password
+          TOX_TESTENV_PASSENV: "PG*"
+        run: |
+          pip install $(grep "^tox==" requirements/local.txt)
+          tox
+    services:
+      postgres:
+        image: postgis/postgis:12-3.0
+        env:
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci_standard.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci_standard.yml
@@ -1,0 +1,50 @@
+name: CI
+on: pull_request
+jobs:
+  test:
+    name: Test -- tox
+    runs-on: ubuntu-16.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+      - name: Get Node.js version
+        id: nvmrc
+        run: echo "::set-output name=version::$(cat .nvmrc)"
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ steps.nvmrc.outputs.version }}
+      - name: Python pip cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements/*.txt') }}
+      - name: Node.js npm cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.npm
+            **/node_modules
+          key: ${{ runner.os }}-node-${{ steps.nvmrc.outputs.version }}-${{ hashFiles('package.json', 'package-lock.json') }}
+      - name: Run tests
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: password
+          TOX_TESTENV_PASSENV: "PG*"
+        run: |
+          pip install $(grep "^tox==" requirements/local.txt)
+          tox
+    services:
+      postgres:
+        image: postgres:12-alpine
+        env:
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5


### PR DESCRIPTION
Time to start moving away from Jenkins.

To test, I've created 2 demo projects based on this template:

https://github.com/developersociety/ci-django-wagtail/pull/1
https://github.com/developersociety/ci-geodjango/pull/1

Which I'll remove once this PR is approved.

This ci.yml is mostly based on (with a few tweaks):

https://github.com/developersociety/bhrrc/blob/dev/.github/workflows/ci.yml - for standard
https://github.com/developersociety/prindex/blob/dev/.github/workflows/ci.yml - for GeoDjango

As the YAML file has tags for if statements, I've had to use separate files for each setup. Only difference between the two is that a GeoDjango site needs GDAL, and has to use postgis for postgres. As these aren't needed for a standard site, it's faster to go without them.

My only concern is that this is all on 16.04, which will probably be EOL in 6 months. However that matches our servers. But on the positive side, when we upgrade - I can use alltherepos pretty quickly without having to clog up Jenkins for over an hour!