### PR TITLE
Change select field default option to empty string

### DIFF
--- a/{{cookiecutter.project_slug}}/project/settings/base.py
+++ b/{{cookiecutter.project_slug}}/project/settings/base.py
@@ -226,7 +226,7 @@ TEMPLATES = [
 ]
 
 # Replace default value in select fields with empty spaces for a more modern look
-BLANK_CHOICE_DASH[0]=(""," ")
+BLANK_CHOICE_DASH[0] = ("", " ")
 
 # Logging
 # https://docs.djangoproject.com/en/{{ cookiecutter.django_version }}/topics/logging/#configuring-logging

--- a/{{cookiecutter.project_slug}}/project/settings/base.py
+++ b/{{cookiecutter.project_slug}}/project/settings/base.py
@@ -12,6 +12,8 @@ import os
 import sys
 from datetime import timedelta
 
+from django.db.models.fields import BLANK_CHOICE_DASH
+
 {%- if cookiecutter.multilingual == 'y' %}
 
 from django.utils.translation import gettext_lazy as _
@@ -222,6 +224,9 @@ TEMPLATES = [
         },
     }
 ]
+
+# Replace default value in select fields with empty spaces for a more modern look
+BLANK_CHOICE_DASH[0]=(""," ")
 
 # Logging
 # https://docs.djangoproject.com/en/{{ cookiecutter.django_version }}/topics/logging/#configuring-logging

--- a/{{cookiecutter.project_slug}}/project/settings/base.py
+++ b/{{cookiecutter.project_slug}}/project/settings/base.py
@@ -13,9 +13,7 @@ import sys
 from datetime import timedelta
 
 from django.db.models.fields import BLANK_CHOICE_DASH
-
 {%- if cookiecutter.multilingual == 'y' %}
-
 from django.utils.translation import gettext_lazy as _
 {%- endif %}
 


### PR DESCRIPTION
### Sources
Change coming from this PR: https://github.com/developersociety/civicusm2m/pull/21
and from this card: https://app.forecast.it/project/P-45/scoping/T4202

### Description
Basically, Paul really dislikes the django default of using "----------" as the default select field option. We agreed blank space would be better than the horrible django default.

### Setup instructions
Nothing special.

### How to test
Create a new instance with cookiecutter and go to /demo-styles and check that selects don't have "--------"
Run make format to check the resulting code is clean

...which I haven't done yet. My cookiecutter installation appears to be broken. And I attempted to fix it and broke tmux, which is basically my OS, so my whole mac workflow feels broken and it's 6pm on a Friday. I need a long hard cry.

For comprehensive guidelines on code review at DEV, see here: https://www.notion.so/developersociety/Code-Review-b6d646b1d6e54011ada8169aee543231.
