### PR TITLE
Change from master to main as the primary branch

### DIFF
--- a/{{cookiecutter.project_slug}}/fabfile.py
+++ b/{{cookiecutter.project_slug}}/fabfile.py
@@ -86,7 +86,7 @@ def cron(remove=None):
 @task
 @roles('web')
 @parallel
-def clone_repo(branch='master'):
+def clone_repo(branch='main'):
     """
     Initial site setup.
 


### PR DESCRIPTION
GitHub is changing the default primary branch for new repositories from master to main.

So let's stay with their new default for new repos - and ensure that our fabfile matches it.