### PR TITLE
Bring back make nuke

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 .DEFAULT_GOAL := help
-PROJECT_SLUG="{{ cookiecutter.project_slug }}"
+PROJECT_SLUG={{ cookiecutter.project_slug }}
 
 # ---------------------------------
 # Project specific targets
@@ -78,6 +78,14 @@ venv-wipe: venv-check
 	if ! pip list --format=freeze | grep -v "^pip=\|^setuptools=\|^wheel=" | xargs pip uninstall -y; then \
 	    echo "Nothing to remove"; \
 	fi
+
+
+# Destructive cleaning
+git-full-clean:
+	git clean -ffdx
+
+database-drop:
+	dropdb --if-exists ${PROJECT_SLUG}_django
 
 
 # Installs


### PR DESCRIPTION
Allow anyone to reset a project locally back to nothing - saving disk space, but leaving the project and virtualenv ready for next time.

To test... maybe not directly...

Have a look at landex (which has a functioning `make nuke` - https://github.com/developersociety/landex/blob/dev/Makefile#L94):

Before:

```
(landex) enlightenment:landex tomkins$ du -sm .
666	.
(landex) enlightenment:landex tomkins$ du -sm ~/.virtualenvs/landex/
333	/Users/tomkins/.virtualenvs/landex/
```

After:

```
(landex) enlightenment:landex tomkins$ du -sm .
32	.
(landex) enlightenment:landex tomkins$ du -sm ~/.virtualenvs/landex/
13	/Users/tomkins/.virtualenvs/landex/
```