### PR TITLE
Upgrade to Wagtail 2.11.3

### DIFF
--- a/{{cookiecutter.project_slug}}/apps/pages/migrations/0002_create_homepage.py
+++ b/{{cookiecutter.project_slug}}/apps/pages/migrations/0002_create_homepage.py
@@ -47,6 +47,10 @@ def remove_homepage(apps, schema_editor):
 
 class Migration(migrations.Migration):
 
+    run_before = [
+        ('wagtailcore', '0053_locale_model'),  # added for Wagtail 2.11 compatibility
+    ]
+
     dependencies = [
         ('contenttypes', '0002_remove_content_type_name'),
         ('pages', '0001_initial'),

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -38,7 +38,7 @@ django-crispy-forms==1.9.2
 {%- if cookiecutter.wagtail == 'y' %}
 
 # Wagtail (core wagtail)
-wagtail==2.11.1
+wagtail==2.11.3
 anyascii==0.1.7
 beautifulsoup4==4.8.2
 django-filter==2.4.0


### PR DESCRIPTION
Noticed this on Slack: https://docs.wagtail.io/en/v2.11.3/releases/2.11.3.html#upgrade-considerations

We haven't been impacted by it yet (migrations might run in different ways!) - but I'm getting it in here now to avoid confusion later.

To test:

```
mktmpenv
cookiecutter --no-input --checkout wagtail-2.11.3 gh:developersociety/django-template wagtail=y
cd projectname
nvm use
make npm-install pip-install-local
dropdb --if-exists projectname_django
createdb projectname_django
./manage.py migrate
make django-dev-createsuperuser
./manage.py runserver
```