### PR TITLE
Use fabric logic for nvm/package-lock changes

### DIFF
--- a/{{cookiecutter.project_slug}}/fabfile.py
+++ b/{{cookiecutter.project_slug}}/fabfile.py
@@ -122,19 +122,21 @@ def update():
         # Install nvm using .nvmrc version
         run('nvm install --no-progress')
 
-        # Check for changes in nvm version and copy to node_modules for future checks
+        # Check for changes in nvm or package-lock.json
         run(
             'cmp --silent .nvmrc node_modules/.nvmrc || '
             'rm -f node_modules/.package-lock.json'
         )
+        run(
+            'cmp --silent package-lock.json node_modules/.nvmrc || '
+            'rm -f node_modules/.package-lock.json'
+        )
 
         # Install node packages
-        run(
-            'cmp --silent package-lock.json node_modules/.package-lock.json || '
-            'npm ci --no-progress && '
-            'cp -a package-lock.json node_modules/.package-lock.json && '
-            'cp -a .nvmrc node_modules/.nvmrc'
-        )
+        if not exists('node_modules/.package-lock.json'):
+            run('npm ci --no-progress')
+            run('cp -a package-lock.json node_modules/.package-lock.json')
+            run('cp -a .nvmrc node_modules/.nvmrc')
 
         # Clean up any potential cruft
         run('find -name "__pycache__" -prune -exec rm -rf {} \;')


### PR DESCRIPTION
On a personal project where I'm also using the template, I thought it was time to improve this chunk of code.

Too much bash logic in the current version (which isn't actually quite right, it always copies the two files), replaced with a bit more Python/fabric. If nvmrc or package-lock change, then node_modules/package-lock.json gets removed - which is then always picked up by the next step.