### PR TITLE
Tweak PYTHONWARNINGS environment variable

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ whitelist_externals =
 passenv =
     GDAL_LIBRARY_PATH
     GEOS_LIBRARY_PATH
-    LIBMEMCACHED
 
 [testenv:django]
 commands =

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -143,7 +143,7 @@ coverage-clean:
 django-check: django-check-missing-migrations django-check-validate-templates
 
 django-test: django-collectstatic
-	coverage run --include="apps/*" ./manage.py test --noinput . apps
+	PYTHONWARNINGS=all coverage run --include="apps/*" ./manage.py test --noinput . apps
 
 django-check-missing-migrations:
 	./manage.py makemigrations --settings=project.settings.migrations --check --dry-run

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -31,4 +31,3 @@ commands = make test-report
 setenv =
     DJANGO_SETTINGS_MODULE = project.settings.tox
     STATIC_ROOT = {envtmpdir}/static
-    PYTHONWARNINGS = all

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -8,12 +8,11 @@ envdir = {toxworkdir}/py38
 deps =
     -rrequirements/base.txt
     -rrequirements/testing.txt
-passenv =
 {%- if cookiecutter.geodjango == 'y' %}
+passenv =
     GDAL_LIBRARY_PATH
     GEOS_LIBRARY_PATH
 {%- endif %}
-    LIBMEMCACHED
 
 [testenv:check]
 whitelist_externals = make


### PR DESCRIPTION
I've held back on tweaking this - it impacts some projects but not others. It felt a bit reactionary committing to this as a workaround. I was also waiting to see if it would be fix upstream quickly, or if I could figure out the difference between some builds failing, and some working.

We've added this on many projects, so hopefully it's nothing dramatic.