### PR TITLE
Python package upgrades

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -1,7 +1,7 @@
-Django==2.2.17
-pytz==2020.4
+Django==2.2.19
+pytz==2021.1
 psycopg2==2.8.6
-Pillow==8.0.1
+Pillow==8.1.2
 olefile==0.46
 dj-database-url==0.5.0
 sqlparse==0.4.1
@@ -15,55 +15,55 @@ django-maskpostgresdata==0.1.13
 
 # Storage
 devsoc-contentfiles==0.3
-django-storages==1.10.1
-boto3==1.16.10
-botocore==1.19.10
+django-storages==1.11.1
+boto3==1.17.30
+botocore==1.20.30
 jmespath==0.10.0
 python-dateutil==2.8.1
-s3transfer==0.3.3
+s3transfer==0.3.4
 six==1.15.0
-urllib3==1.25.11
+urllib3==1.26.4
 
 # Reporting (Errors, APM)
-elastic-apm==5.9.0
-sentry-sdk==0.19.2
-certifi==2020.6.20
+elastic-apm==6.0.0
+sentry-sdk==1.0.0
+certifi==2020.12.5
 
 # Axes
-django-axes==5.8.0
-django-ipware==3.0.1
+django-axes==5.13.1
+django-ipware==3.0.2
 
 # Form styling
-django-crispy-forms==1.9.2
+django-crispy-forms==1.11.1
 {%- if cookiecutter.wagtail == 'y' %}
 
 # Wagtail (core wagtail)
-wagtail==2.11.3
+wagtail==2.11.6
 anyascii==0.1.7
 beautifulsoup4==4.8.2
 django-filter==2.4.0
 django-modelcluster==5.1
 django-taggit==1.3.0
-django-treebeard==4.3.1
+django-treebeard==4.5.1
 djangorestframework==3.12.2
 draftjs-exporter==2.1.7
 et-xmlfile==1.0.1
 html5lib==1.1
 jdcal==1.4.1
 l18n==2020.6.1
-openpyxl==3.0.5
-soupsieve==2.0.1
-tablib==2.0.0
+openpyxl==3.0.7
+soupsieve==2.2
+tablib==3.0.0
 webencodings==0.5.1
 Willow==1.4
-xlrd==1.2.0
+xlrd==2.0.1
 XlsxWriter==1.3.7
 xlwt==1.3.0
 
 # Requests (wagtail)
-requests==2.24.0
+requests==2.25.1
 idna==2.10
-chardet==3.0.4
+chardet==4.0.0
 
 # Wagtail extras
 wagtailfontawesome==1.2.1

--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -1,7 +1,7 @@
 -r testing.txt
 
-awscli==1.18.170
-django-debug-toolbar==3.1.1
-ipdb==0.13.4
+awscli==1.19.30
+django-debug-toolbar==3.2
+ipdb==0.13.7
 pywatchman==1.4.1
-tox==3.20.1
+tox==3.23.0

--- a/{{cookiecutter.project_slug}}/requirements/testing.txt
+++ b/{{cookiecutter.project_slug}}/requirements/testing.txt
@@ -1,10 +1,10 @@
 -r base.txt
 
 black==20.8b1
-coverage==5.3
-django-extensions==3.0.9
-flake8==3.8.4
-isort==5.6.4
-pipdeptree==1.0.0
-factory-boy==3.1.0
+coverage==5.5
+django-extensions==3.1.1
+flake8==3.9.0
+isort==5.7.0
+pipdeptree==2.0.0
+factory-boy==3.2.0
 unittest-xml-reporting==3.0.4


### PR DESCRIPTION
I'm quietly working on a Django 3.2 branch, but a few things need upgrading first.

To test:

```
mktmpenv
cookiecutter --no-input --checkout march-upgrades gh:developersociety/django-template wagtail=y
cd projectname
nvm use
make npm-install pip-install-local
dropdb --if-exists projectname_django
createdb projectname_django
./manage.py migrate
make django-dev-createsuperuser
./manage.py runserver
```