### PR TITLE
Django 3.2 and Wagtail 2.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Get Node.js version
         id: nvmrc
         run: echo "::set-output name=version::$(cat .nvmrc)"

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,7 +1,7 @@
 {
     "project_name": "Project Name",
     "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '').replace('-', '').replace('_', '') }}",
-    "django_version": ["2.2"],
+    "django_version": ["3.2"],
     "multilingual": "n",
     "geodjango": "n",
     "wagtail": "n",

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ envlist = django, django-multilingual, geodjango, wagtail, wagtail-multilingual
 skipsdist = true
 
 [testenv]
-basepython = python3.8
-envdir = {toxworkdir}/py38
+basepython = python3.9
+envdir = {toxworkdir}/py39
 deps =
     cookiecutter==1.7.2
 changedir = {envtmpdir}

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci_geodjango.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci_geodjango.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Get Node.js version
         id: nvmrc
         run: echo "::set-output name=version::$(cat .nvmrc)"

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci_standard.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci_standard.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Get Node.js version
         id: nvmrc
         run: echo "::set-output name=version::$(cat .nvmrc)"

--- a/{{cookiecutter.project_slug}}/manage.py
+++ b/{{cookiecutter.project_slug}}/manage.py
@@ -5,6 +5,7 @@ import sys
 
 
 def main():
+    """Run administrative tasks."""
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "project.settings.local")
     try:
         from django.core.management import execute_from_command_line

--- a/{{cookiecutter.project_slug}}/project/asgi.py
+++ b/{{cookiecutter.project_slug}}/project/asgi.py
@@ -1,0 +1,12 @@
+"""
+ASGI config - Django {{ cookiecutter.django_version }}.
+
+It exposes the ASGI callable as a module-level variable named ``application``.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/{{ cookiecutter.django_version }}/howto/deployment/asgi/
+"""
+
+from django.core.asgi import get_asgi_application
+
+application = get_asgi_application()

--- a/{{cookiecutter.project_slug}}/project/settings/base.py
+++ b/{{cookiecutter.project_slug}}/project/settings/base.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/{{ cookiecutter.django_version }}/ref/settings
 import os
 import sys
 from datetime import timedelta
+from pathlib import Path
 
 from django.db.models.fields import BLANK_CHOICE_DASH
 {%- if cookiecutter.multilingual == 'y' %}
@@ -19,8 +20,8 @@ from django.utils.translation import gettext_lazy as _
 
 import dj_database_url
 
-# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+# Build paths inside the project like this: BASE_DIR / "subdir".
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 # Production / development switches
 # https://docs.djangoproject.com/en/{{ cookiecutter.django_version }}/howto/deployment/checklist/
@@ -39,8 +40,8 @@ SERVER_EMAIL = "{{ cookiecutter.project_slug }}@devsoc.org"
 DEFAULT_FROM_EMAIL = "{{ cookiecutter.project_slug }}@devsoc.org"
 EMAIL_SUBJECT_PREFIX = "[{{ cookiecutter.project_slug }}] "
 
-PROJECT_APPS_ROOT = os.path.join(BASE_DIR, "apps")
-sys.path.append(PROJECT_APPS_ROOT)
+PROJECT_APPS_ROOT = BASE_DIR / "apps"
+sys.path.append(PROJECT_APPS_ROOT.as_posix())
 
 DEFAULT_APPS = [
     # These apps should come first to load correctly.
@@ -171,7 +172,7 @@ USE_TZ = True
 # Allowed languages
 LANGUAGES = [("en", _("English")), ("uni", _("Unicode Test"))]
 
-LOCALE_PATHS = [os.path.join(BASE_DIR, "locale")]
+LOCALE_PATHS = [BASE_DIR / "locale"]
 {%- endif %}
 
 # Static files (CSS, JavaScript, Images)
@@ -179,22 +180,27 @@ LOCALE_PATHS = [os.path.join(BASE_DIR, "locale")]
 
 STATIC_URL = os.environ.get("STATIC_URL", "/static/")
 
-STATIC_ROOT = os.path.join(BASE_DIR, "htdocs/static")
+STATIC_ROOT = BASE_DIR / "htdocs/static"
 
 STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
 
-STATICFILES_DIRS = [os.path.join(BASE_DIR, "static")]
+STATICFILES_DIRS = [BASE_DIR / "static"]
 
 # File uploads
 # https://docs.djangoproject.com/en/{{ cookiecutter.django_version }}/ref/settings/#file-uploads
 
 MEDIA_URL = os.environ.get("MEDIA_URL", "/media/")
 
-MEDIA_ROOT = os.path.join(BASE_DIR, "htdocs/media")
+MEDIA_ROOT = BASE_DIR / "htdocs/media"
 
 DEFAULT_FILE_STORAGE = os.environ.get(
     "DEFAULT_FILE_STORAGE", "django.core.files.storage.FileSystemStorage"
 )
+
+# Default primary key field type
+# https://docs.djangoproject.com/en/{{ cookiecutter.django_version }}/ref/settings/#default-auto-field
+
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 # Templates
 # https://docs.djangoproject.com/en/{{ cookiecutter.django_version }}/ref/settings/#templates
@@ -202,7 +208,7 @@ DEFAULT_FILE_STORAGE = os.environ.get(
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [os.path.join(BASE_DIR, "templates")],
+        "DIRS": [BASE_DIR / "templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -39,26 +39,26 @@ django-crispy-forms==1.11.1
 {%- if cookiecutter.wagtail == 'y' %}
 
 # Wagtail (core wagtail)
-wagtail==2.11.7
-anyascii==0.1.7
-beautifulsoup4==4.8.2
+wagtail==2.13
+anyascii==0.2.0
+beautifulsoup4==4.9.3
 django-filter==2.4.0
 django-modelcluster==5.1
-django-taggit==1.3.0
+django-taggit==1.4.0
 django-treebeard==4.5.1
-djangorestframework==3.12.2
+djangorestframework==3.12.4
 draftjs-exporter==2.1.7
-et-xmlfile==1.0.1
+et-xmlfile==1.1.0
 html5lib==1.1
-jdcal==1.4.1
 l18n==2020.6.1
 openpyxl==3.0.7
-soupsieve==2.2
+soupsieve==2.2.1
 tablib==3.0.0
+telepath==0.1.1
 webencodings==0.5.1
 Willow==1.4
 xlrd==2.0.1
-XlsxWriter==1.3.7
+XlsxWriter==1.4.3
 xlwt==1.3.0
 
 # Requests (wagtail)

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -17,25 +17,25 @@ django-maskpostgresdata==0.1.13
 # Storage
 devsoc-contentfiles==0.3
 django-storages==1.11.1
-boto3==1.17.30
-botocore==1.20.30
+boto3==1.17.72
+botocore==1.20.72
 jmespath==0.10.0
 python-dateutil==2.8.1
-s3transfer==0.3.4
-six==1.15.0
+s3transfer==0.4.2
+six==1.16.0
 urllib3==1.26.4
 
 # Reporting (Errors, APM)
-elastic-apm==6.0.0
-sentry-sdk==1.0.0
+elastic-apm==6.1.3
+sentry-sdk==1.1.0
 certifi==2020.12.5
 
 # Axes
-django-axes==5.13.1
+django-axes==5.15.0
 django-ipware==3.0.2
 
 # Form styling
-django-crispy-forms==1.11.1
+django-crispy-forms==1.11.2
 {%- if cookiecutter.wagtail == 'y' %}
 
 # Wagtail (core wagtail)
@@ -73,7 +73,7 @@ wagtailfontawesome==1.2.1
 elasticsearch==6.4.0
 
 # Wagtail 2FA
-django-otp==1.0.2
+django-otp==1.0.5
 qrcode==6.1
 wagtail-2fa==1.4.2
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -1,7 +1,8 @@
-Django==2.2.20
+Django==3.2.3
+asgiref==3.3.4
 pytz==2021.1
 psycopg2==2.8.6
-Pillow==8.1.2
+Pillow==8.2.0
 olefile==0.46
 dj-database-url==0.5.0
 sqlparse==0.4.1

--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -1,7 +1,7 @@
 -r testing.txt
 
-awscli==1.19.30
-django-debug-toolbar==3.2
+awscli==1.19.72
+django-debug-toolbar==3.2.1
 ipdb==0.13.7
 pywatchman==1.4.1
-tox==3.23.0
+tox==3.23.1

--- a/{{cookiecutter.project_slug}}/requirements/testing.txt
+++ b/{{cookiecutter.project_slug}}/requirements/testing.txt
@@ -1,10 +1,10 @@
 -r base.txt
 
-black==20.8b1
+black==21.5b1
 coverage==5.5
-django-extensions==3.1.1
-flake8==3.9.0
-isort==5.7.0
+django-extensions==3.1.3
+flake8==3.9.2
+isort==5.8.0
 pipdeptree==2.0.0
 factory-boy==3.2.0
 unittest-xml-reporting==3.0.4

--- a/{{cookiecutter.project_slug}}/templates/404.html
+++ b/{{cookiecutter.project_slug}}/templates/404.html
@@ -4,11 +4,11 @@
 
 {% block main %}
   <div class="container">
-    <h1>{% trans '404 - page not found' %}</h1>
+    <h1>{% translate '404 - page not found' %}</h1>
 
-    <p>{% trans "We couldn't find the page you are looking for." %}</p>
+    <p>{% translate "We couldn't find the page you are looking for." %}</p>
 
-    <p>{% trans 'If you entered the URL manually please check your spelling and try again.' %}</p>
+    <p>{% translate 'If you entered the URL manually please check your spelling and try again.' %}</p>
 
     <p><a class="button" href="/">Back to homepage</a></p>
   </div>

--- a/{{cookiecutter.project_slug}}/templates/500.html
+++ b/{{cookiecutter.project_slug}}/templates/500.html
@@ -4,7 +4,7 @@
 
 <html lang="{{ LANGUAGE_CODE }}"{% if LANGUAGE_BIDI %} dir="rtl"{% endif %}>
   <head>
-    <title>{% trans 'Server error!' %}</title>
+    <title>{% translate 'Server error!' %}</title>
     <style type="text/css">
       body { color: #000000; background-color: #ffffff; }
       p { margin-left: 3em; }
@@ -12,11 +12,11 @@
     </style>
   </head>
   <body>
-    <h1>{% trans 'Server error!' %}</h1>
+    <h1>{% translate 'Server error!' %}</h1>
 
-    <p>{% trans 'The server encountered an internal error and was unable to complete your request.' %}</p>
+    <p>{% translate 'The server encountered an internal error and was unable to complete your request.' %}</p>
 
-    <h2>{% trans 'Error 500' %}</h2>
+    <h2>{% translate 'Error 500' %}</h2>
 
     <p>
       <span class="server-info">

--- a/{{cookiecutter.project_slug}}/templates/base.html
+++ b/{{cookiecutter.project_slug}}/templates/base.html
@@ -21,7 +21,7 @@
   <body>
     {% if DEMO_SITE %}
       <div class="demo-announcement">
-        <div class="container">{% trans 'This site is in development. Any changes made here will not be transferred to the production build.' %}</div>
+        <div class="container">{% translate 'This site is in development. Any changes made here will not be transferred to the production build.' %}</div>
       </div>
     {% endif %}
 

--- a/{{cookiecutter.project_slug}}/templates/base_wagtail.html
+++ b/{{cookiecutter.project_slug}}/templates/base_wagtail.html
@@ -29,7 +29,7 @@
 
     {% if DEMO_SITE %}
       <div class="demo-announcement">
-        <div class="container">{% trans 'This site is in development. Any changes made here will not be transferred to the production build.' %}</div>
+        <div class="container">{% translate 'This site is in development. Any changes made here will not be transferred to the production build.' %}</div>
       </div>
     {% endif %}
 

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -3,8 +3,8 @@ envlist = check, lint, tests
 skipsdist = true
 
 [testenv]
-basepython = python3.8
-envdir = {toxworkdir}/py38
+basepython = python3.9
+envdir = {toxworkdir}/py39
 deps =
     -rrequirements/base.txt
     -rrequirements/testing.txt


### PR DESCRIPTION
To test:

```
mktmpenv
cookiecutter --no-input --checkout django32 gh:developersociety/django-template wagtail=y
cd projectname
nvm use
make npm-install pip-install-local
dropdb --if-exists projectname_django
createdb projectname_django
./manage.py migrate
make django-dev-createsuperuser
./manage.py runserver
```

Note: Wagtail 2.13 isn't an LTS release, 2.15 (November 2021) is the next LTS release. If we're starting a Wagtail project - let's use this, however hold off on upgrading existing projects until later this year.