### PR TITLE
Package upgrades (Wagtail 2.14)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skipsdist = true
 basepython = python3.9
 envdir = {toxworkdir}/py39
 deps =
-    cookiecutter==1.7.2
+    cookiecutter==1.7.3
 changedir = {envtmpdir}
 whitelist_externals =
     bash

--- a/{{cookiecutter.project_slug}}/apps/pages/migrations/0002_create_homepage.py
+++ b/{{cookiecutter.project_slug}}/apps/pages/migrations/0002_create_homepage.py
@@ -5,6 +5,7 @@ def create_homepage(apps, schema_editor):
     # Get models
     ContentType = apps.get_model('contenttypes.ContentType')
     Page = apps.get_model('wagtailcore.Page')
+    Locale = apps.get_model('wagtailcore.Locale')
     Site = apps.get_model('wagtailcore.Site')
     HomePage = apps.get_model('pages.HomePage')
 
@@ -17,6 +18,10 @@ def create_homepage(apps, schema_editor):
         model='homepage', app_label='pages'
     )
 
+    # Default locale - there should only be one locale in the database at this point, so a .get
+    # should work
+    locale = Locale.objects.get()
+
     # Create a new homepage
     homepage = HomePage.objects.create(
         title="Home",
@@ -27,6 +32,7 @@ def create_homepage(apps, schema_editor):
         depth=2,
         numchild=0,
         url_path='/home/',
+        locale=locale,
     )
 
     # Create a site with the new homepage set as the root
@@ -37,7 +43,6 @@ def create_homepage(apps, schema_editor):
 
 def remove_homepage(apps, schema_editor):
     # Get models
-    ContentType = apps.get_model('contenttypes.ContentType')
     HomePage = apps.get_model('pages.HomePage')
 
     # Delete the default homepage
@@ -47,14 +52,10 @@ def remove_homepage(apps, schema_editor):
 
 class Migration(migrations.Migration):
 
-    run_before = [
-        ('wagtailcore', '0053_locale_model'),  # added for Wagtail 2.11 compatibility
-    ]
-
     dependencies = [
         ('contenttypes', '0002_remove_content_type_name'),
         ('pages', '0001_initial'),
-        ('wagtailcore', '0041_group_collection_permissions_verbose_name_plural'),
+        ('wagtailcore', '0062_comment_models_and_pagesubscription'),
     ]
 
     operations = [

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -1,50 +1,50 @@
-Django==3.2.3
-asgiref==3.3.4
+Django==3.2.6
+asgiref==3.4.1
 pytz==2021.1
 psycopg2==2.8.6
-Pillow==8.2.0
+Pillow==8.3.1
 olefile==0.46
 dj-database-url==0.5.0
 sqlparse==0.4.1
 
 # Caching
-django-redis==4.12.1
+django-redis==5.0.0
 redis==3.5.3
 
 # Masked database backups
-django-maskpostgresdata==0.1.13
+django-maskpostgresdata==0.1.14
 
 # Storage
 devsoc-contentfiles==0.3
 django-storages==1.11.1
-boto3==1.17.72
-botocore==1.20.72
+boto3==1.18.12
+botocore==1.21.12
 jmespath==0.10.0
-python-dateutil==2.8.1
-s3transfer==0.4.2
+python-dateutil==2.8.2
+s3transfer==0.5.0
 six==1.16.0
-urllib3==1.26.4
+urllib3==1.26.6
 
 # Reporting (Errors, APM)
-elastic-apm==6.1.3
-sentry-sdk==1.1.0
-certifi==2020.12.5
+elastic-apm==6.3.3
+sentry-sdk==1.3.1
+certifi==2021.5.30
 
 # Axes
-django-axes==5.15.0
-django-ipware==3.0.2
+django-axes==5.20.0
+django-ipware==3.0.7
 
 # Form styling
-django-crispy-forms==1.11.2
+django-crispy-forms==1.12.0
 {%- if cookiecutter.wagtail == 'y' %}
 
 # Wagtail (core wagtail)
-wagtail==2.13
+wagtail==2.14
 anyascii==0.2.0
 beautifulsoup4==4.9.3
 django-filter==2.4.0
 django-modelcluster==5.1
-django-taggit==1.4.0
+django-taggit==1.5.1
 django-treebeard==4.5.1
 djangorestframework==3.12.4
 draftjs-exporter==2.1.7
@@ -54,27 +54,27 @@ l18n==2020.6.1
 openpyxl==3.0.7
 soupsieve==2.2.1
 tablib==3.0.0
-telepath==0.1.1
+telepath==0.2
 webencodings==0.5.1
 Willow==1.4
 xlrd==2.0.1
-XlsxWriter==1.4.3
+XlsxWriter==1.4.5
 xlwt==1.3.0
 
 # Requests (wagtail)
-requests==2.25.1
-idna==2.10
-chardet==4.0.0
+requests==2.26.0
+idna==3.2
+charset-normalizer==2.0.4
 
 # Wagtail extras
 wagtailfontawesome==1.2.1
 
 # Wagtail search
-elasticsearch==6.4.0
+elasticsearch==6.8.2
 
 # Wagtail 2FA
-django-otp==1.0.5
-qrcode==6.1
+django-otp==1.0.6
+qrcode==7.2
 wagtail-2fa==1.4.2
 {%- endif %}
 

--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -1,7 +1,7 @@
 -r testing.txt
 
-awscli==1.19.72
+awscli==1.20.12
 django-debug-toolbar==3.2.1
-ipdb==0.13.7
+ipdb==0.13.9
 pywatchman==1.4.1
-tox==3.23.1
+tox==3.24.1

--- a/{{cookiecutter.project_slug}}/requirements/testing.txt
+++ b/{{cookiecutter.project_slug}}/requirements/testing.txt
@@ -1,10 +1,10 @@
 -r base.txt
 
-black==21.5b1
+black==21.7b0
 coverage==5.5
 django-extensions==3.1.3
 flake8==3.9.2
-isort==5.8.0
-pipdeptree==2.0.0
+isort==5.9.3
+pipdeptree==2.1.0
 factory-boy==3.2.0
 unittest-xml-reporting==3.0.4


### PR DESCRIPTION
To test:

```
mktmpenv
cookiecutter --no-input --checkout package-upgrades gh:developersociety/django-template wagtail=y
cd projectname
nvm use
make npm-install pip-install-local
dropdb --if-exists projectname_django
createdb projectname_django
./manage.py migrate
make django-dev-createsuperuser
./manage.py runserver
```

Couple of notes:

- This includes an improved homepage migration which has been used on a couple of projects. Wagtail's docs suggest `run_before` - but that seems to be an issue if you nuke migrations on a project.
- New version of requests now uses charset-normalizer instead of chardet

I think Wagtail 2.14 seems like a fairly easy upgrade - so hopefully nothing to worry about for the 2 projects which are on 2.13.