### PR TITLE
Faster ci tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,15 @@ jobs:
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+      - name: Configure Postgres (for faster tests)
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: password
+        run: |
+          psql -c "ALTER SYSTEM SET fsync=off;"
+          psql -c "ALTER SYSTEM SET full_page_writes=off;"
+          psql -c "SELECT pg_reload_conf();"
       - name: Run tests
         env:
           PGHOST: localhost

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci_standard.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci_standard.yml
@@ -31,6 +31,15 @@ jobs:
             ~/.npm
             **/node_modules
           key: ${{ runner.os }}-node-${{ steps.nvmrc.outputs.version }}-${{ hashFiles('package.json', 'package-lock.json') }}
+      - name: Configure Postgres (for faster tests)
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: password
+        run: |
+          psql -c "ALTER SYSTEM SET fsync=off;"
+          psql -c "ALTER SYSTEM SET full_page_writes=off;"
+          psql -c "SELECT pg_reload_conf();"
       - name: Run tests
         env:
           PGHOST: localhost

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -53,6 +53,9 @@ lint: npm-install black-lint isort-lint flake8-lint eslint-lint prettier-lint
 test: ## Run unit and integration tests.
 test: django-test
 
+test-fast: ## Run tests in parallel, without reports
+test-fast: django-test-fast
+
 test-report: ## Run and report on unit and integration tests.
 test-report: coverage-clean test coverage-report
 
@@ -144,6 +147,9 @@ django-check: django-check-missing-migrations django-check-validate-templates
 
 django-test: django-collectstatic
 	PYTHONWARNINGS=all coverage run --include="apps/*" ./manage.py test --noinput . apps
+
+django-test-fast: django-collectstatic
+    PYTHONWARNINGS=all ./manage.py test --noinput --parallel
 
 django-check-missing-migrations:
 	./manage.py makemigrations --settings=project.settings.migrations --check --dry-run

--- a/{{cookiecutter.project_slug}}/requirements/testing.txt
+++ b/{{cookiecutter.project_slug}}/requirements/testing.txt
@@ -6,5 +6,6 @@ django-extensions==3.1.5
 flake8==4.0.1
 isort==5.10.1
 pipdeptree==2.2.0
+tblib==1.7.0
 factory-boy==3.2.1
 unittest-xml-reporting==3.0.4


### PR DESCRIPTION
# Sources
https://github.com/developersociety/bhrrc/pull/883

# Description
Switches Github postgres instance to a faster less-crash-resistant mode.  But if it crashes, during running tests, honestly, we don't care about missing data.  Just run it again.

![Sonic](https://media.giphy.com/media/yXVO50FJIJMSQ/giphy.gif)

# How to test
I'm not really sure!
