### PR TITLE
Set wagtail search backend to be default postgres / database.

### DIFF
--- a/{{cookiecutter.project_slug}}/project/settings/base.py
+++ b/{{cookiecutter.project_slug}}/project/settings/base.py
@@ -312,13 +312,19 @@ WAGTAIL_SITE_NAME = "{{ cookiecutter.project_name }}"
 BASE_URL = os.environ.get("WAGTAIL_BASE_URL", "")
 WAGTAIL_ENABLE_UPDATE_CHECK = False
 WAGTAIL_REDIRECTS_FILE_STORAGE = "cache"
-WAGTAILSEARCH_BACKENDS = {
-    "default": {
-        "BACKEND": "wagtail.search.backends.elasticsearch6",
-        "URLS": [os.environ.get("SEARCH_URL", "http://127.0.0.1:9200")],
-        "INDEX": os.environ.get("SEARCH_INDEX", f"{PROJECT_SLUG}"),
+
+# Wagtail search - use Postgres unless ENABLE_ELASTICSEARCH is enabled with environment vars
+# eg. ENABLE_ELASTICSEARCH=1 ./manage.py runserver
+if os.environ.get("ENABLE_ELASTICSEARCH"):
+    WAGTAILSEARCH_BACKENDS = {
+        "default": {
+            "BACKEND": "wagtail.search.backends.elasticsearch6",
+            "URLS": [os.environ.get("SEARCH_URL", "http://127.0.0.1:9200")],
+            "INDEX": os.environ.get("SEARCH_INDEX", f"{PROJECT_SLUG}"),
+        }
     }
-}
+else:
+    WAGTAILSEARCH_BACKENDS = {"default": {"BACKEND": "wagtail.search.backends.database"}}
 
 # Ask wagtail to put some wrapper divs w/ classes around media
 # embeds which make doing CSS selectors for responsiveness easier.

--- a/{{cookiecutter.project_slug}}/project/settings/local.py
+++ b/{{cookiecutter.project_slug}}/project/settings/local.py
@@ -53,10 +53,3 @@ PASSWORD_HASHERS = [
 
 # Disable axes for local usage
 AXES_ENABLED = False
-{%- if cookiecutter.wagtail == 'y' %}
-
-# Wagtail search - use Postgres unless ENABLE_ELASTICSEARCH is enabled with environment vars
-# eg. ENABLE_ELASTICSEARCH=1 ./manage.py runserver
-if not os.environ.get("ENABLE_ELASTICSEARCH"):
-    WAGTAILSEARCH_BACKENDS = {"default": {"BACKEND": "wagtail.search.backends.database"}}
-{%- endif %}


### PR DESCRIPTION
# Description
After various discussions, and now that the postgres / database backend is improved (wagtail 2.15?) we're now switching to that being the default, instead of default being elasticsearch.

# Setup instructions
_Include any environment variables etc. that are needed to test your code._
_Anything not specific to testing just this PR would be better in the README._

# How to test
```sh
mktmpenv --python=python3.10
pip install cookiecutter
cookiecutter --no-input --checkout use-postgres-search-by-default gh:developersociety/django-template wagtail=y
cd projectname
nvm use
make npm-install pip-install-local
dropdb --if-exists projectname_django
createdb projectname_django
./manage.py migrate
make django-dev-createsuperuser
./manage.py update_index
```

For comprehensive guidelines on code review at DEV, see here: https://www.notion.so/developersociety/Code-Review-f804361f9b6b4859bdcd69d7704168e5.
