### PR TITLE
Allow fab get_media to filter on file extension

### DIFF
--- a/{{cookiecutter.project_slug}}/fabfile.py
+++ b/{{cookiecutter.project_slug}}/fabfile.py
@@ -279,20 +279,22 @@ def get_backup(hostname=None, replace_hostname='127.0.0.1', replace_port=8000):
 
 
 @task
-def get_media(directory=''):
+def get_media(directory='', filetype=None):
     """
     Download remote media files. It uses credentials from ~/.aws/config.
 
     fab get_media
     fab get_media:assets
+    fab get_media:filetype=jpg
     """
+    params = '--exclude "*" --include "*.{ext}"'.format(ext=filetype) if filetype else ""
     # Sync files from our S3 bucket/directory
     local(
         'aws-vault exec devsoc-contentfiles-download -- '
         'aws s3 sync '
         's3://{media_bucket}/{media}/{directory} '
-        'htdocs/media/{directory}'.format(
-            media_bucket=env.media_bucket, media=env.media, directory=directory
+        'htdocs/media/{directory} {params}'.format(
+            media_bucket=env.media_bucket, media=env.media, directory=directory, params=params
         )
     )
 


### PR DESCRIPTION
I often comment out get_media from the get_data make command because I don't want to wait for all that to download, and don't often need it all anyway.

Thought might be helpful to someone else, also on some sites might want this to be behaviour for make reset even.

In some circumstances I have found it useful to at least be able to avoid downloading pdfs etc and just skip to the images that affect appearance/layout of site. Often then stop the get_media halfway anyway.