### PR TITLE
Fix missing users in admin

### DIFF
--- a/{{cookiecutter.project_slug}}/apps/accounts/admin.py
+++ b/{{cookiecutter.project_slug}}/apps/accounts/admin.py
@@ -1,0 +1,18 @@
+from django.contrib import admin
+from django.contrib.auth.admin import GroupAdmin as BaseGroupAdmin, UserAdmin as BaseUserAdmin
+from django.contrib.auth.models import Group as BaseGroup
+
+from .models import Group, User
+
+
+@admin.register(User)
+class UserAdmin(BaseUserAdmin):
+    pass
+
+
+admin.site.unregister(BaseGroup)
+
+
+@admin.register(Group)
+class GroupAdmin(BaseGroupAdmin):
+    pass

--- a/{{cookiecutter.project_slug}}/apps/accounts/migrations/0001_initial.py
+++ b/{{cookiecutter.project_slug}}/apps/accounts/migrations/0001_initial.py
@@ -16,6 +16,20 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.CreateModel(
+            name='Group',
+            fields=[
+            ],
+            options={
+                'proxy': True,
+                'indexes': [],
+                'constraints': [],
+            },
+            bases=('auth.group',),
+            managers=[
+                ('objects', django.contrib.auth.models.GroupManager()),
+            ],
+        ),
+        migrations.CreateModel(
             name='User',
             fields=[
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),

--- a/{{cookiecutter.project_slug}}/apps/accounts/models.py
+++ b/{{cookiecutter.project_slug}}/apps/accounts/models.py
@@ -1,8 +1,13 @@
-from django.contrib.auth.models import AbstractUser
+from django.contrib.auth.models import AbstractUser, Group as BaseGroup
 
 
 class User(AbstractUser):
-    pass
-
     class Meta:
         db_table = "auth_user"
+
+
+# To allow groups to set alongside users in the Django admin - we use a proxy model back to the
+# default group model and re-register it this app.
+class Group(BaseGroup):
+    class Meta:
+        proxy = True


### PR DESCRIPTION
# Description

Fixes missing user admin in the Django admin.

This also uses a proxy model to help get users/groups in the same section in the Django admin.

# How to test

```
mktmpenv --python=python3.10
cookiecutter --no-input --checkout fix-custom-user-admin gh:developersociety/django-template
cd projectname
nvm use
make npm-install pip-install-local
dropdb --if-exists projectname_django
createdb projectname_django
./manage.py migrate
make django-dev-createsuperuser
./manage.py runserver
```

Check http://127.0.0.1:8000/admin/ - are Users/Groups back in the admin?