### PR TITLE
Python3.12, django 5, ruff, etc.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: 'requirements/*.txt'
       - name: Setup Node.js

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,7 +1,7 @@
 {
     "project_name": "Project Name",
     "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '').replace('-', '').replace('_', '') }}",
-    "django_version": ["3.2"],
+    "django_version": ["5.0.4"],
     "multilingual": "n",
     "geodjango": "n",
     "_copy_without_render": [

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,7 +1,7 @@
 {
     "project_name": "Project Name",
     "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '').replace('-', '').replace('_', '') }}",
-    "django_version": ["5.0.4"],
+    "django_version": ["5.0"],
     "multilingual": "n",
     "geodjango": "n",
     "_copy_without_render": [

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ envlist = django, django-multilingual, geodjango
 skipsdist = true
 
 [testenv]
-basepython = python3.10
-envdir = {toxworkdir}/py310
+basepython = python3.12
+envdir = {toxworkdir}/py312
 deps =
     -rrequirements/testing.txt
 changedir = {envtmpdir}

--- a/tox.ini
+++ b/tox.ini
@@ -17,14 +17,14 @@ passenv =
 [testenv:django]
 commands =
     cookiecutter --no-input {toxinidir}
-    bash -c "cd projectname && tox"
+    bash -c "rm {envdir}/.gitignore && cd projectname && tox"
 
 [testenv:django-multilingual]
 commands =
     cookiecutter --no-input {toxinidir} multilingual=y
-    bash -c "cd projectname && tox"
+    bash -c "rm {envdir}/.gitignore && cd projectname && tox"
 
 [testenv:geodjango]
 commands =
     cookiecutter --no-input {toxinidir} geodjango=y
-    bash -c "cd projectname && tox"
+    bash -c "rm {envdir}/.gitignore && cd projectname && tox"

--- a/{{cookiecutter.project_slug}}/.git-blame-ignore-revs
+++ b/{{cookiecutter.project_slug}}/.git-blame-ignore-revs
@@ -1,0 +1,1 @@
+# Only If you need to do a batch reformatting in this repo, then please list the commit here.

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci_geodjango.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci_geodjango.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: 'requirements/*.txt'
       - name: Setup Node.js

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci_standard.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci_standard.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: 'requirements/*.txt'
       - name: Setup Node.js

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -45,10 +45,10 @@ check: ## Check for any obvious errors in the project's setup.
 check: pipdeptree-check npm-check django-check
 
 format: ## Run this project's code formatters.
-format: black-format isort-format prettier-format
+format: ruff-format black-format isort-format prettier-format djlint-format
 
 lint: ## Lint the project.
-lint: npm-install black-lint isort-lint flake8-lint eslint-lint prettier-lint
+lint: ruff-lint black-lint isort-lint flake8-lint npm-install eslint-lint prettier-lint djlint-lint djlint-check
 
 test: ## Run unit and integration tests.
 test: django-test
@@ -111,6 +111,15 @@ fab-get-media:
 
 fab-deploy:
 	fab deploy
+
+
+# Ruff
+ruff-lint:
+	ruff check .
+	ruff format --check apps project
+
+ruff-format:
+	ruff check --fix-only .
 
 
 # ISort
@@ -207,6 +216,17 @@ black-lint:
 
 black-format:
 	black apps project
+
+
+# DJ lint
+djlint-lint:
+	djlint templates --lint
+
+djlint-check:
+	djlint templates --check
+
+djlint-format:
+	djlint templates --reformat
 
 
 #pipdeptree

--- a/{{cookiecutter.project_slug}}/apps/core/context_processors.py
+++ b/{{cookiecutter.project_slug}}/apps/core/context_processors.py
@@ -25,8 +25,7 @@ def browsersync_url(host):
         return None
 
     cache_time = int(time.time())
-    url = BROWSERSYNC_URL.format(host=host, port=port, time=cache_time)
-    return url
+    return BROWSERSYNC_URL.format(host=host, port=port, time=cache_time)
 
 
 def browsersync(request):

--- a/{{cookiecutter.project_slug}}/project/settings/base.py
+++ b/{{cookiecutter.project_slug}}/project/settings/base.py
@@ -118,8 +118,6 @@ USE_I18N = True
 USE_I18N = False
 {%- endif %}
 
-USE_L10N = True
-
 USE_TZ = True
 
 {%- if cookiecutter.multilingual == 'y' %}

--- a/{{cookiecutter.project_slug}}/project/settings/base.py
+++ b/{{cookiecutter.project_slug}}/project/settings/base.py
@@ -243,7 +243,7 @@ AUTHENTICATION_BACKENDS = [
     "axes.backends.AxesBackend",
     "django.contrib.auth.backends.ModelBackend",
 ]
-AXES_ONLY_USER_FAILURES = True
+AXES_LOCKOUT_PARAMETERS = ["username"]
 AXES_FAILURE_LIMIT = 10
 AXES_COOLOFF_TIME = timedelta(minutes=15)
 AXES_ENABLE_ADMIN = False

--- a/{{cookiecutter.project_slug}}/project/settings/base.py
+++ b/{{cookiecutter.project_slug}}/project/settings/base.py
@@ -133,11 +133,9 @@ LOCALE_PATHS = [BASE_DIR / "locale"]
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/{{ cookiecutter.django_version }}/howto/static-files/
 
-STATIC_URL = os.environ.get("STATIC_URL", "/static/")
+STATIC_URL = os.environ.get("STATIC_URL", "static/")
 
 STATIC_ROOT = BASE_DIR / "htdocs/static"
-
-STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
 
 STATICFILES_DIRS = [BASE_DIR / "static"]
 
@@ -148,9 +146,16 @@ MEDIA_URL = os.environ.get("MEDIA_URL", "/media/")
 
 MEDIA_ROOT = BASE_DIR / "htdocs/media"
 
-DEFAULT_FILE_STORAGE = os.environ.get(
-    "DEFAULT_FILE_STORAGE", "django.core.files.storage.FileSystemStorage"
-)
+STORAGES = {
+    "default": {
+        "BACKEND": os.environ.get(
+            "DEFAULT_FILE_STORAGE", "django.core.files.storage.FileSystemStorage"
+        ),
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage",
+    },
+}
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/{{ cookiecutter.django_version }}/ref/settings/#default-auto-field

--- a/{{cookiecutter.project_slug}}/project/settings/local.py
+++ b/{{cookiecutter.project_slug}}/project/settings/local.py
@@ -28,7 +28,7 @@ INSTALLED_APPS += ["django_extensions"]
 TEMPLATES[0]["OPTIONS"]["context_processors"].append("core.context_processors.browsersync")
 
 # Use vanilla StaticFilesStorage to allow tests to run outside of tox easily
-STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
+STORAGES["staticfiles"]["BACKEND"] = "django.contrib.staticfiles.storage.StaticFilesStorage"
 
 SECRET_KEY = "secret"
 

--- a/{{cookiecutter.project_slug}}/project/settings/local.py
+++ b/{{cookiecutter.project_slug}}/project/settings/local.py
@@ -10,7 +10,7 @@ DATABASES = {
 {%- if cookiecutter.geodjango == 'y' %}
         "ENGINE": "django.contrib.gis.db.backends.postgis",
 {%- else %}
-        "ENGINE": "django.db.backends.postgresql_psycopg2",
+        "ENGINE": "django.db.backends.postgresql",
 {%- endif %}
         "NAME": os.environ.get("DJANGO_DATABASE_NAME", "{{ cookiecutter.project_slug }}_django"),
         "USER": "",

--- a/{{cookiecutter.project_slug}}/project/settings/local.py
+++ b/{{cookiecutter.project_slug}}/project/settings/local.py
@@ -43,7 +43,7 @@ if not os.environ.get("DISABLE_TOOLBAR"):
 
 # Allow login with remote passwords, but downgrade/swap to crypt for password hashing speed
 PASSWORD_HASHERS = [
-    "django.contrib.auth.hashers.CryptPasswordHasher",
+    "django.contrib.auth.hashers.MD5PasswordHasher",
     "django.contrib.auth.hashers.PBKDF2PasswordHasher",
 ]
 

--- a/{{cookiecutter.project_slug}}/project/settings/local.py
+++ b/{{cookiecutter.project_slug}}/project/settings/local.py
@@ -41,7 +41,7 @@ if not os.environ.get("DISABLE_TOOLBAR"):
 
     MIDDLEWARE = ["debug_toolbar.middleware.DebugToolbarMiddleware"] + MIDDLEWARE
 
-# Allow login with remote passwords, but downgrade/swap to crypt for password hashing speed
+# Allow login with remote passwords, but downgrade/swap for faster password hashing speed
 PASSWORD_HASHERS = [
     "django.contrib.auth.hashers.MD5PasswordHasher",
     "django.contrib.auth.hashers.PBKDF2PasswordHasher",

--- a/{{cookiecutter.project_slug}}/project/settings/tox.py
+++ b/{{cookiecutter.project_slug}}/project/settings/tox.py
@@ -25,7 +25,7 @@ TEST_RUNNER = "xmlrunner.extra.djangotestrunner.XMLTestRunner"
 TEST_OUTPUT_DIR = "reports"
 
 # Always run tests with the fastest password hasher
-PASSWORD_HASHERS = ["django.contrib.auth.hashers.CryptPasswordHasher"]
+PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
 
 # Disable axes during testing
 AXES_ENABLED = False

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -39,7 +39,7 @@ extend_exclude="field.html"
 "tree.html" = "H025"
 
 [tool.ruff]
-exclude = ["apps/*/migrations"]
+extend-exclude = ["apps/*/migrations"]
 line-length = 99
 
 [tool.ruff.lint]

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 99
-target-version = ['py39']
+target-version = ['py312']
 exclude = '/migrations/'
 
 [tool.isort]

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -14,3 +14,60 @@ force_grid_wrap = 0
 line_length = 99
 multi_line_output = 3
 skip_glob = '*/migrations/*.py'
+
+[tool.djlint]
+profile = "django"
+indent = 2
+blank_line_after_tag = "load,extends"
+line_break_after_multiline_tag = true
+close_void_tags = true
+max_length = 120
+# T002 - Double quotes should be used in tags
+ignore = "T002"
+# Bootsrtap file from crispy forms - too many issues with it
+extend_exclude="field.html"
+
+[tool.djlint.per-file-ignores]
+# Disable:
+# H006 - Img tag should have height and width attributes
+# H025 - Tag seems to be an orphan.
+# H030 - Consider adding a meta description
+# H031 - Consider adding meta keywords
+"500.html" = "H030,H031"
+"base.html" = "H030,H031"
+"demo_styles.html" = "H006"
+"tree.html" = "H025"
+
+[tool.ruff]
+exclude = ["apps/*/migrations"]
+line-length = 99
+
+[tool.ruff.lint]
+ignore = [
+    "F405",
+    "W605",
+    "N802", # Ignore lowercase function name rule- conflicts with assertEqual etc.
+]
+# Adds additional rules to the default "E" (pycodestyle) and "F" (pyflakes)
+extend-select = [
+    "W",       # pycodestyle Warning,                                                                    see https://docs.astral.sh/ruff/rules/#warning-w
+    "N",       # pep8-naming,                                                                            see https://docs.astral.sh/ruff/rules/#pep8-naming-n
+    "YTT",     # flake8-2020 flake8 plugin which checks for misuse of sys.version or sys.version_info,   see https://docs.astral.sh/ruff/rules/#flake8-2020-ytt
+    "BLE",     # checks for blind, catch all except and except Exception statements,                     see https://docs.astral.sh/ruff/rules/#flake8-blind-except-ble
+    "B",       # flake8-bugbear,                                                                         see https://docs.astral.sh/ruff/rules/#flake8-bugbear-b
+    "A",       # checks for variables that use Python builtin names,                                     see https://docs.astral.sh/ruff/rules/#flake8-builtins-a
+    "T100",    # Check for pdb;idbp imports and set traces,                                              see https://docs.astral.sh/ruff/rules/#flake8-debugger-t10
+    "DJ001",   # Avoid using null=True on string-based fields such as CharField and TextField,           see https://docs.astral.sh/ruff/rules/django-nullable-model-string-field/
+    "DJ003",   # Avoid passing locals() as context to a render function,                                 see https://docs.astral.sh/ruff/rules/django-locals-in-render-function/
+    "DJ012",   # Check that the order of model's inner classes, methods, and fields,                     see https://docs.astral.sh/ruff/rules/django-unordered-body-content-in-model/
+    "ISC",     # looks for style problems like implicitly concatenated string literals on the same line, see https://docs.astral.sh/ruff/rules/#flake8-implicit-str-concat-isc
+    "INP001",  # Checks for packages that are missing an __init__.py file,                               see https://docs.astral.sh/ruff/rules/#flake8-no-pep420-inp
+    "PIE",     # flake8-pie, multiple tools,                                                             see https://docs.astral.sh/ruff/rules/#flake8-pie-pie
+    "T20",     # removes print and pprint statements,                                                    see https://docs.astral.sh/ruff/rules/#flake8-print-t20
+    "RET",     # multiple rules,                                                                         see https://docs.astral.sh/ruff/rules/#flake8-return-ret
+    "SIM107",  # Checks for return statements in try-except and finally blocks,                          see https://docs.astral.sh/ruff/rules/return-in-try-except-finally/
+    "SIM114",  # Checks for if branches with identical arm bodies,                                       see https://docs.astral.sh/ruff/rules/if-with-same-arms/
+    "SIM115",  # Checks for usages of the builtin open() function without an associated context manager, see https://docs.astral.sh/ruff/rules/open-file-with-context-handler/
+    "PD",      # Pandas best practices,                                                                  see https://docs.astral.sh/ruff/rules/#pandas-vet-pd
+]
+

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -1,42 +1,46 @@
-Django==3.2.25
-asgiref==3.6.0
-pytz==2022.7.1
-psycopg2==2.9.5
-Pillow==10.0.1
-olefile==0.46
-dj-database-url==1.2.0
-sqlparse==0.4.3
+Django==5.0.4
+asgiref==3.8.1
+pytz==2024.1
+psycopg==3.1.18
+olefile==0.47
+dj-database-url==2.1.0
+sqlparse==0.5.0
 
 # Caching
-django-redis==5.2.0
+django-redis==5.4.0
 async-timeout==4.0.2
-redis==4.5.1
+redis==5.0.4
 
 # Masked database backups
-django-maskpostgresdata==0.1.16
+django-maskpostgresdata==0.2.1
 
 # Storage
 devsoc-contentfiles==0.3
-django-storages==1.13.2
-boto3==1.20.6
-botocore==1.23.6
-jmespath==0.10.0
-python-dateutil==2.8.2
-s3transfer==0.5.0
+django-storages==1.14.2
+boto3==1.34.91
+botocore==1.34.91
+jmespath==1.0.1
+python-dateutil==2.9.0.post0
+s3transfer==0.10.1
 six==1.16.0
-urllib3==1.26.14
+urllib3==2.2.1
 
 # Reporting (Errors, APM)
-elastic-apm==6.14.0
-sentry-sdk==1.23.1
-certifi==2022.12.7
+elastic-apm==6.22.0
+sentry-sdk==1.45.0
+certifi==2024.2.2
+ecs-logging==2.1.0
+wrapt==1.14.1
+
+# Cookie filtering
+django-cookiefilter==1.0
 
 # Axes
-django-axes==5.40.1
+django-axes==6.4.0
 django-ipware==4.0.2
 
 # Form styling
-django-crispy-forms==1.13.0
+django-crispy-forms==1.14.0
 {%- if cookiecutter.multilingual == 'y' %}
 
 # Translations

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -1,10 +1,10 @@
 Django==5.0.4
 asgiref==3.8.1
-pytz==2024.1
 psycopg==3.1.18
 olefile==0.47
 dj-database-url==2.1.0
 sqlparse==0.5.0
+typing_extensions==4.11.0
 
 # Caching
 django-redis==5.4.0

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -32,9 +32,6 @@ certifi==2024.2.2
 ecs-logging==2.1.0
 wrapt==1.14.1
 
-# Cookie filtering
-django-cookiefilter==1.0
-
 # Axes
 django-axes==6.4.0
 django-ipware==4.0.2

--- a/{{cookiecutter.project_slug}}/requirements/testing.txt
+++ b/{{cookiecutter.project_slug}}/requirements/testing.txt
@@ -1,11 +1,15 @@
 -r base.txt
 
-black==22.3.0
-coverage==6.1.2
-django-extensions==3.1.5
-flake8==4.0.1
-isort==5.10.1
-pipdeptree==2.2.0
-tblib==1.7.0
-factory-boy==3.2.1
-unittest-xml-reporting==3.0.4
+black==24.4.1
+coverage==7.5.0
+django-extensions==3.2.3
+factory-boy==3.3.0
+flake8==7.0.0
+isort==5.13.2
+pipdeptree==2.18.1
+ruff==0.4.1
+tblib==3.0.0
+unittest-xml-reporting==3.2.0
+
+# DJ lint
+djlint==1.34.1

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -3,8 +3,8 @@ envlist = check, lint, tests
 skipsdist = true
 
 [testenv]
-basepython = python3.10
-envdir = {toxworkdir}/py310
+basepython = python3.12
+envdir = {toxworkdir}/py312
 deps =
     -rrequirements/base.txt
     -rrequirements/testing.txt


### PR DESCRIPTION
- Update to python 3.12
- Updates django to 5.x
- Include ruff for formatting & linting (not removing `black`/`isort`/`flake8` yet (but we could?)