### PR TITLE
Do apt-get update before install packages in CI

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/ci_geodjango.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci_geodjango.yml
@@ -15,6 +15,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Install Ubuntu packages
         run: |
+          sudo apt-get update
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
             libgdal30
       - name: Setup Python


### PR DESCRIPTION
# Sources
https://developersociety.slack.com/archives/CGAPG8DC7/p1721980928960569

https://github.com/developersociety/batshelpline/pull/84

# Description
We need to `apt-get update` before trying to install extra packages in CI needed for geodjango.