### PR TITLE
Mailpit

### DIFF
--- a/{{cookiecutter.project_slug}}/project/settings/base.py
+++ b/{{cookiecutter.project_slug}}/project/settings/base.py
@@ -235,6 +235,9 @@ LOGGING = {
 # Sites framework
 SITE_ID = 1
 
+# Default URL scheme (when request context isn't available)
+URL_SCHEME = "https"
+
 # Cloud storage
 CONTENTFILES_PREFIX = os.environ.get("CONTENTFILES_PREFIX", f"{PROJECT_SLUG}")
 CONTENTFILES_HOSTNAME = os.environ.get("CONTENTFILES_HOSTNAME")

--- a/{{cookiecutter.project_slug}}/project/settings/local.py
+++ b/{{cookiecutter.project_slug}}/project/settings/local.py
@@ -33,7 +33,13 @@ STORAGES["staticfiles"]["BACKEND"] = "django.contrib.staticfiles.storage.StaticF
 
 SECRET_KEY = "secret"  # noqa:S105
 
-EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+# Implement mailpit if env var is present
+# eg. MAILPIT=1 ./manage.py runserver
+if os.environ.get("MAILPIT"):
+    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+    EMAIL_PORT = 1025
+else:
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 # Django debug toolbar - show locally unless DISABLE_TOOLBAR is enabled with environment vars
 # eg. DISABLE_TOOLBAR=1 ./manage.py runserver

--- a/{{cookiecutter.project_slug}}/project/settings/local.py
+++ b/{{cookiecutter.project_slug}}/project/settings/local.py
@@ -25,6 +25,9 @@ INTERNAL_IPS = ["127.0.0.1"]
 ALLOWED_HOSTS = ["*"]
 INSTALLED_APPS += ["django_extensions"]
 
+# Default URL scheme (when request context isn't available)
+URL_SCHEME = "http"
+
 # Webpack runserver
 TEMPLATES[0]["OPTIONS"]["context_processors"].append("core.context_processors.browsersync")
 


### PR DESCRIPTION
Copies across the env var toggle for mailpit.

Also, adding in a `URL_SCHEME` setting which has historically been on a lot of sites. It's mostly unused by default, but if there's ever a need to do something like sending an email - but you have no access to the request variable - this makes it slightly easier to vary in local vs production.